### PR TITLE
Fix SVN lock errors with automatic cleanup and retry

### DIFF
--- a/src/claudeconnect/svn_ops.py
+++ b/src/claudeconnect/svn_ops.py
@@ -38,6 +38,16 @@ class SvnError(Exception):
     pass
 
 
+class SvnLockError(SvnError):
+    """SVN working copy is locked."""
+    pass
+
+
+def is_lock_error(stderr: str) -> bool:
+    """Check if an SVN error is a working copy lock error."""
+    return "E155004" in stderr or "is already locked" in stderr
+
+
 class SvnClient:
     """SVN client for Claude Connect operations."""
 
@@ -114,7 +124,7 @@ class SvnClient:
         Raises:
             SvnError: If update fails.
         """
-        result = self._run(["update", "--accept", "postpone"])
+        result = self._with_cleanup_retry("update", ["update", "--accept", "postpone"])
 
         if result.returncode != 0:
             raise SvnError(f"Update failed: {result.stderr}")
@@ -135,7 +145,7 @@ class SvnClient:
         Returns:
             SvnStatus object with categorized file lists.
         """
-        result = self._run(["status"])
+        result = self._with_cleanup_retry("status", ["status"])
 
         if result.returncode != 0:
             raise SvnError(f"Status failed: {result.stderr}")
@@ -252,7 +262,7 @@ class SvnClient:
         Raises:
             SvnError: If commit fails.
         """
-        result = self._run(["commit", "-m", message])
+        result = self._with_cleanup_retry("commit", ["commit", "-m", message])
 
         if result.returncode != 0:
             if "nothing to commit" in result.stderr.lower():
@@ -322,6 +332,40 @@ class SvnClient:
     def is_working_copy(self) -> bool:
         """Check if the working directory is an SVN working copy."""
         return self.info() is not None
+
+    def cleanup(self) -> bool:
+        """
+        Clean up the working copy, removing stale locks.
+
+        Returns:
+            True if successful.
+        """
+        result = self._run(["cleanup"])
+        return result.returncode == 0
+
+    def _with_cleanup_retry(self, operation: str, args: list[str], cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+        """
+        Run an SVN command with automatic cleanup retry on lock errors.
+
+        Args:
+            operation: Human-readable operation name for error messages.
+            args: SVN command arguments.
+            cwd: Working directory override.
+
+        Returns:
+            CompletedProcess result.
+
+        Raises:
+            SvnError: If operation fails even after cleanup retry.
+        """
+        result = self._run(args, cwd)
+
+        if result.returncode != 0 and is_lock_error(result.stderr):
+            # Working copy is locked - try cleanup and retry once
+            self.cleanup()
+            result = self._run(args, cwd)
+
+        return result
 
 
 def email_to_repo_name(email: str) -> str:

--- a/src/claudeconnect/sync.py
+++ b/src/claudeconnect/sync.py
@@ -79,6 +79,9 @@ class SyncLoop:
         # Run SVN operations in thread pool to avoid blocking
         loop = asyncio.get_event_loop()
 
+        # Clean up any stale locks before operations
+        await loop.run_in_executor(None, self.svn.cleanup)
+
         # Pull remote changes
         try:
             updated = await loop.run_in_executor(None, self.svn.update)
@@ -155,6 +158,9 @@ def sync_once(context_dir: Path, repo_url: str, svn_token: str, email: str) -> b
     svn = SvnClient(context_dir, repo_url, svn_token, email)
 
     try:
+        # Clean up any stale locks from previous sessions
+        svn.cleanup()
+
         # Pull updates
         updated = svn.update()
         if updated:


### PR DESCRIPTION
## Summary
- Fixes the `svn: E155004: Working copy is locked` errors that occur when SVN operations are interrupted
- Adds automatic lock detection and cleanup before retry
- Runs `svn cleanup` proactively at the start of each sync cycle

## Problem
When an SVN operation (update, commit, etc.) is interrupted mid-execution (due to crash, timeout, or network issues), it leaves the working copy locked. All subsequent operations fail with:
```
svn: E155004: Run 'svn cleanup' to remove locks
svn: E155004: Working copy '/Users/bstadt/root/claude' locked.
```

## Solution
1. Added `cleanup()` method to `SvnClient` - wraps `svn cleanup`
2. Added `_with_cleanup_retry()` helper that:
   - Runs the SVN command
   - If it fails with E155004 lock error, runs cleanup and retries once
3. Updated `update()`, `status()`, and `commit()` to use auto-retry
4. Modified sync loops to run `svn cleanup` proactively at the start of each cycle

## Test plan
- [x] Code review
- [ ] Test with a locked working copy (simulate by killing an svn operation mid-flight)
- [ ] Test normal sync operations still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)