### PR TITLE
Fix: Push conversations to recipient's repo via authz

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -131,6 +131,10 @@ def generate_authz_content(email: str, private_files: list[str] | None = None) -
         "[/claudeconnect/friend_requests]",
         "* = rw",
         f"{email} = rw",
+        "",
+        "# Friends can write conversations to your repo",
+        "[/claudeconnect/conversations]",
+        f"{email} = rw",
     ]
 
     # Add private file sections - only owner has access
@@ -679,6 +683,114 @@ def pull(peer_email: str):
         sys.exit(1)
 
 
+def add_friend_to_authz(authz_path: Path, my_email: str, peer_email: str) -> bool:
+    """
+    Add a friend to the authz file with appropriate permissions.
+
+    Grants:
+    - Read access to [/] (can read your context)
+    - Write access to [/claudeconnect/conversations] (can push conversations to you)
+
+    Args:
+        authz_path: Path to authz file
+        my_email: Owner's email
+        peer_email: Friend's email to add
+
+    Returns:
+        True if changes were made, False if friend already has access.
+    """
+    authz_content = authz_path.read_text()
+    lines = authz_content.split('\n')
+    new_lines = []
+    changes_made = False
+
+    # Track which sections we've seen
+    current_section = None
+    added_to_root = False
+    added_to_conversations = False
+    conversations_section_exists = False
+
+    # Check if friend already has access
+    has_root_access = f"{peer_email} = r" in authz_content or f"{peer_email} = rw" in authz_content
+    has_conv_access = False
+
+    # Check conversations section specifically
+    in_conv_section = False
+    for line in lines:
+        if line.strip().startswith('['):
+            in_conv_section = '[/claudeconnect/conversations]' in line
+            if in_conv_section:
+                conversations_section_exists = True
+        elif in_conv_section and peer_email in line:
+            has_conv_access = True
+
+    # Process lines and add friend where needed
+    for i, line in enumerate(lines):
+        new_lines.append(line)
+
+        # Track current section
+        if line.strip().startswith('['):
+            current_section = line.strip()
+
+        # Add read access after owner's rw line in [/] section
+        if (current_section == '[/]' and
+            not added_to_root and
+            not has_root_access and
+            '= rw' in line and
+            my_email in line):
+            new_lines.append(f"{peer_email} = r")
+            added_to_root = True
+            changes_made = True
+            print(f"  Added {peer_email} read access to [/]")
+
+        # Add write access after owner's rw line in [/claudeconnect/conversations] section
+        if (current_section == '[/claudeconnect/conversations]' and
+            not added_to_conversations and
+            not has_conv_access and
+            '= rw' in line and
+            my_email in line):
+            new_lines.append(f"{peer_email} = rw")
+            added_to_conversations = True
+            changes_made = True
+            print(f"  Added {peer_email} write access to [/claudeconnect/conversations]")
+
+    # If conversations section doesn't exist, add it
+    if not conversations_section_exists:
+        new_lines.append("")
+        new_lines.append("# Friends can write conversations to your repo")
+        new_lines.append("[/claudeconnect/conversations]")
+        new_lines.append(f"{my_email} = rw")
+        new_lines.append(f"{peer_email} = rw")
+        changes_made = True
+        print(f"  Created [/claudeconnect/conversations] section")
+        print(f"  Added {peer_email} write access to [/claudeconnect/conversations]")
+    elif not added_to_conversations and not has_conv_access:
+        # Section exists but we didn't find owner's line - append to end of section
+        # Find the conversations section and add after it
+        final_lines = []
+        in_conv = False
+        added = False
+        for line in new_lines:
+            final_lines.append(line)
+            if '[/claudeconnect/conversations]' in line:
+                in_conv = True
+            elif in_conv and not added:
+                # Add after first line of section
+                final_lines.append(f"{peer_email} = rw")
+                added = True
+                changes_made = True
+                print(f"  Added {peer_email} write access to [/claudeconnect/conversations]")
+                in_conv = False
+        new_lines = final_lines
+
+    if changes_made:
+        authz_path.write_text('\n'.join(new_lines))
+    else:
+        print(f"  {peer_email} already has access in your authz")
+
+    return changes_made
+
+
 @cli.command()
 @click.argument("peer_email")
 @click.option("--message", "-m", default="Hi! I'd like to connect our Claude instances.", help="Message to include")
@@ -686,7 +798,7 @@ def friend(peer_email: str, message: str):
     """Send a friend request to another user.
 
     This command:
-    1. Updates your authz to grant them read access
+    1. Updates your authz to grant them read access + conversation write access
     2. Sends a friend request to their repo
     """
     tokens = get_valid_token()
@@ -708,7 +820,7 @@ def friend(peer_email: str, message: str):
 
     print(f"Sending friend request to {peer_email}...")
 
-    # Step 1: Update local authz to grant them read access
+    # Step 1: Update local authz to grant them appropriate access
     context_dir = Path(config.context_dir)
     authz_path = context_dir / "authz"
 
@@ -716,29 +828,7 @@ def friend(peer_email: str, message: str):
         print("Error: authz file not found. Run `claudeconnect init` first.")
         sys.exit(1)
 
-    authz_content = authz_path.read_text()
-
-    # Check if they already have access
-    if f"{peer_email} = r" in authz_content or f"{peer_email} = rw" in authz_content:
-        print(f"  {peer_email} already has access in your authz")
-    else:
-        # Add them to the [/] section
-        # Find the [/] section and add after the owner line
-        lines = authz_content.split('\n')
-        new_lines = []
-        added = False
-        for line in lines:
-            new_lines.append(line)
-            # Add after the owner's rw line in [/] section
-            if not added and '= rw' in line and my_email in line:
-                new_lines.append(f"{peer_email} = r")
-                added = True
-
-        if added:
-            authz_path.write_text('\n'.join(new_lines))
-            print(f"  Added {peer_email} to your authz")
-        else:
-            print("  Warning: Could not auto-update authz. Please add manually.")
+    add_friend_to_authz(authz_path, my_email, peer_email)
 
     # Step 2: Sync to commit authz changes
     svn_token = get_svn_token(tokens.id_token)
@@ -763,6 +853,7 @@ def friend(peer_email: str, message: str):
         if response.status_code == 200:
             print(f"\n✓ Friend request sent to {peer_email}")
             print(f"  They will see your request in their claudeconnect/friend_requests/ folder.")
+            print(f"  Once they accept, they can send you conversations.")
         elif response.status_code == 404:
             print(f"\n✗ User {peer_email} not found on ClaudeConnect")
             sys.exit(1)

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -3,7 +3,7 @@ name: claudeconnect
 description: Manages ClaudeConnect for sharing context between Claude instances. Use for syncing files, managing friends, pulling friend context, starting conversations, and handling friend requests.
 metadata:
   author: theexgenesis
-  version: "1.0"
+  version: "1.1"
 ---
 
 # ClaudeConnect Skill
@@ -81,7 +81,7 @@ claudeconnect session <email> [-t "topic"]     # Start conversation session
 ### Sending a Friend Request
 
 The `claudeconnect friend` command does two things automatically:
-1. Adds the recipient to your `authz` file with read access
+1. Adds the recipient to your `authz` file with read access to `/` and write access to `/claudeconnect/conversations`
 2. Sends a friend request to their `claudeconnect/friend_requests/` folder
 
 ```bash
@@ -111,16 +111,22 @@ Each file contains:
 
 ### Accepting a Friend Request
 
-1. Add them to your `authz` file:
+1. Add them to your `authz` file with TWO permissions:
    ```
    [/]
    owner@email.com = rw
-   alice@example.com = r    # Add this line
+   alice@example.com = r    # Can read your context
+
+   [/claudeconnect/conversations]
+   owner@email.com = rw
+   alice@example.com = rw   # Can write conversations to you
    ```
 
 2. Delete the request file from `claudeconnect/friend_requests/`
 
 3. Sync: `claudeconnect sync`
+
+**Important:** The `[/claudeconnect/conversations]` write access allows friends to push conversation transcripts to your repo when they initiate a session with you.
 
 ### Rejecting a Request
 
@@ -128,20 +134,26 @@ Simply delete the request file without updating authz, then sync.
 
 ## The authz File
 
-Controls who can read your context:
+Controls who can read your context and write conversations:
 
 ```
 [/]
 owner@email.com = rw           # You have full access
-friend1@example.com = r        # Friend has read access
+friend1@example.com = r        # Friend can read your context
 friend2@test.org = r           # Another friend
 
 [/claudeconnect/friend_requests]
 * = rw                         # Anyone can write friend requests
 owner@email.com = rw
+
+# Friends can write conversations to your repo
+[/claudeconnect/conversations]
+owner@email.com = rw
+friend1@example.com = rw       # Friend can push conversations to you
+friend2@test.org = rw          # Another friend
 ```
 
-To remove a friend: delete their line from `[/]` and sync.
+To remove a friend: delete their lines from both `[/]` and `[/claudeconnect/conversations]`, then sync.
 
 ## Reading Friend Context
 
@@ -171,9 +183,13 @@ This:
 1. Pulls their latest context
 2. Runs Claude with both contexts loaded
 3. Generates a conversation transcript
-4. Commits transcript to both repos
+4. Commits transcript to both repos (yours and theirs)
 
-Transcripts are saved to: `claudeconnect/conversations/with-<email>/<session-id>.md`
+Transcripts are saved to:
+- Your repo: `claudeconnect/conversations/with-<friend>/<session-id>.md`
+- Friend's repo: `claudeconnect/conversations/with-<you>/<session-id>.md`
+
+**Note:** For the friend's repo commit to succeed, they must have granted you write access to `[/claudeconnect/conversations]` in their authz.
 
 ## Excluding Files from Sync
 
@@ -211,7 +227,7 @@ svn delete --keep-local <path>
 
 ## Privacy Considerations
 
-**What friends can see:** Everything committed to your SVN repo.
+**What friends can see:** Everything committed to your SVN repo (except private files in authz).
 
 **Best practices:**
 1. **Never commit credentials** - API keys, passwords, tokens
@@ -328,6 +344,14 @@ claudeconnect sync                   # Re-sync
 ### "No context directory configured"
 Run `claudeconnect init` in your context directory first.
 
+### "Failed to commit to peer's repo"
+This means the peer hasn't granted you write access to their conversations folder.
+Ask them to add to their authz:
+```
+[/claudeconnect/conversations]
+your@email.com = rw
+```
+
 ## API Endpoints (Advanced)
 
 For direct API access (requires `Authorization: Bearer {id_token}` header):
@@ -352,7 +376,7 @@ I found a friend request from alice@example.com sent yesterday.
 They wrote: "Hey, let's connect our Claudes!"
 
 Would you like me to:
-1. Accept (I'll update your authz and sync)
+1. Accept (I'll update your authz with read + conversation write access and sync)
 2. Reject (I'll delete the request)
 3. Ignore for now
 ```
@@ -365,8 +389,9 @@ Claude: I'll send a friend request to bob@example.com.
 *runs: claudeconnect friend bob@example.com -m "Hi! Let's connect."*
 
 ✓ Friend request sent! They'll see it in their claudeconnect/friend_requests/ folder.
-Once they accept and grant you access, you can pull their context with:
-claudeconnect pull bob@example.com
+Once they accept and grant you conversation write access, you can:
+- Pull their context: claudeconnect pull bob@example.com
+- Start a session: claudeconnect session bob@example.com
 ```
 
 ### User asks to see a friend's context


### PR DESCRIPTION
## Summary

Fixes #7 - Conversations are now properly pushed to the recipient's repo by updating authz to grant write access to the conversations folder.

### Changes

**`cli.py`:**
- `generate_authz_content()`: Now includes `[/claudeconnect/conversations]` section in new authz files
- New `add_friend_to_authz()` helper function that grants both:
  - Read access to `[/]` (can read your context)
  - Write access to `[/claudeconnect/conversations]` (can push conversations to you)
- `friend` command: Uses the new helper to properly set up bidirectional conversation support

**`SKILL.md`:**
- Updated friend acceptance workflow to include conversation write access
- Documented the authz structure for conversations
- Added troubleshooting section for "Failed to commit to peer's repo"
- Updated example interactions to reflect new permissions model

### How it works

1. When Alice friends Bob, Alice's authz now grants Bob write access to `/claudeconnect/conversations`
2. When Bob starts a session with Alice, the transcript commits to both repos:
   - Bob's repo: `claudeconnect/conversations/with-alice/...`
   - Alice's repo: `claudeconnect/conversations/with-bob/...`
3. Both parties have their own copy of the conversation

### Migration for existing users

Existing users need to manually add the conversations section to their authz:

```
[/claudeconnect/conversations]
owner@email.com = rw
friend1@email.com = rw
friend2@email.com = rw
```

## Test plan

- [ ] New user init creates authz with conversations section
- [ ] `claudeconnect friend` adds both read and conversation write access
- [ ] Session transcripts commit to both sender and recipient repos
- [ ] Existing authz files get conversations section added when friending