### PR TITLE
Add accept-friend and reject-friend CLI commands

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1018,6 +1018,133 @@ def friend(peer_email: str, message: str):
         sys.exit(1)
 
 
+@cli.command("accept-friend")
+@click.argument("peer_email")
+def accept_friend(peer_email: str):
+    """Accept a pending friend request.
+
+    This command:
+    1. Updates your authz to grant them read access + conversation write access
+    2. Deletes the friend request file
+    3. Syncs changes to the server so they can access your context
+    """
+    tokens = get_valid_token()
+    if not tokens:
+        print("Not logged in or token expired. Run `claudeconnect login` first.")
+        sys.exit(1)
+
+    config = get_config()
+    if not config.context_dir:
+        print("No context directory configured. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    peer_email = peer_email.strip().lower()
+    my_email = tokens.email
+
+    if peer_email == my_email:
+        print("Cannot accept friend request from yourself.")
+        sys.exit(1)
+
+    context_dir = Path(config.context_dir)
+
+    # Check if friend request exists
+    friend_requests_dir = context_dir / "claudeconnect" / "friend_requests"
+    request_file = friend_requests_dir / f"{peer_email}.json"
+
+    if not request_file.exists():
+        print(f"No friend request found from {peer_email}")
+        print(f"  Checked: {request_file}")
+        sys.exit(1)
+
+    print(f"Accepting friend request from {peer_email}...")
+
+    # Step 1: Update local authz to grant them appropriate access
+    authz_path = context_dir / "authz"
+
+    if not authz_path.exists():
+        print("Error: authz file not found. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    add_friend_to_authz(authz_path, my_email, peer_email)
+
+    # Step 2: Delete the friend request file
+    try:
+        request_file.unlink()
+        print(f"  Removed friend request file")
+    except Exception as e:
+        print(f"  Warning: Could not delete request file: {e}")
+
+    # Step 3: Sync to commit authz changes and request deletion
+    svn_token = get_svn_token(tokens.id_token)
+    if not svn_token:
+        print("Failed to get SVN token")
+        sys.exit(1)
+
+    repo_url = repo_url_for_email(my_email)
+    print("  Syncing changes to server...")
+    sync_once(context_dir, repo_url, svn_token, my_email)
+
+    print(f"\n✓ Friend request accepted!")
+    print(f"  {peer_email} can now read your context and send you conversations.")
+    print(f"  Pull their context with: claudeconnect pull {peer_email}")
+
+
+@cli.command("reject-friend")
+@click.argument("peer_email")
+def reject_friend(peer_email: str):
+    """Reject a pending friend request.
+
+    This command:
+    1. Deletes the friend request file without granting access
+    2. Syncs changes to the server
+    """
+    tokens = get_valid_token()
+    if not tokens:
+        print("Not logged in or token expired. Run `claudeconnect login` first.")
+        sys.exit(1)
+
+    config = get_config()
+    if not config.context_dir:
+        print("No context directory configured. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    peer_email = peer_email.strip().lower()
+    my_email = tokens.email
+
+    context_dir = Path(config.context_dir)
+
+    # Check if friend request exists
+    friend_requests_dir = context_dir / "claudeconnect" / "friend_requests"
+    request_file = friend_requests_dir / f"{peer_email}.json"
+
+    if not request_file.exists():
+        print(f"No friend request found from {peer_email}")
+        print(f"  Checked: {request_file}")
+        sys.exit(1)
+
+    print(f"Rejecting friend request from {peer_email}...")
+
+    # Delete the friend request file
+    try:
+        request_file.unlink()
+        print(f"  Removed friend request file")
+    except Exception as e:
+        print(f"  Error: Could not delete request file: {e}")
+        sys.exit(1)
+
+    # Sync to commit the deletion
+    svn_token = get_svn_token(tokens.id_token)
+    if not svn_token:
+        print("Failed to get SVN token")
+        sys.exit(1)
+
+    repo_url = repo_url_for_email(my_email)
+    print("  Syncing changes to server...")
+    sync_once(context_dir, repo_url, svn_token, my_email)
+
+    print(f"\n✓ Friend request rejected.")
+
+
 # =============================================================================
 # Test User Commands
 # =============================================================================

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -72,6 +72,8 @@ claudeconnect start      # Same as above (explicit)
 
 ```bash
 claudeconnect friend <email> [-m "message"]   # Send friend request
+claudeconnect accept-friend <email>            # Accept incoming friend request
+claudeconnect reject-friend <email>            # Reject incoming friend request
 claudeconnect pull <email>                     # Pull friend's context locally
 claudeconnect session <email> [-t "topic"]     # Start conversation session
 ```
@@ -111,26 +113,26 @@ Each file contains:
 
 ### Accepting a Friend Request
 
-1. Add them to your `authz` file with TWO permissions:
-   ```
-   [/]
-   owner@email.com = rw
-   alice@example.com = r    # Can read your context
+Use the `accept-friend` command to accept a friend request. This automatically:
+1. Updates your authz file with read access and conversation write access
+2. Deletes the friend request file
+3. Syncs all changes to the server
 
-   [/claudeconnect/conversations]
-   owner@email.com = rw
-   alice@example.com = rw   # Can write conversations to you
-   ```
+```bash
+claudeconnect accept-friend alice@example.com
+```
 
-2. Delete the request file from `claudeconnect/friend_requests/`
-
-3. Sync: `claudeconnect sync`
-
-**Important:** The `[/claudeconnect/conversations]` write access allows friends to push conversation transcripts to your repo when they initiate a session with you.
+**Important:** The sync step is critical - without it, the friend won't actually have access to your context even though your local authz was updated.
 
 ### Rejecting a Request
 
-Simply delete the request file without updating authz, then sync.
+Use the `reject-friend` command to reject a request:
+
+```bash
+claudeconnect reject-friend alice@example.com
+```
+
+This deletes the request file and syncs without granting any access.
 
 ## The authz File
 
@@ -376,8 +378,8 @@ I found a friend request from alice@example.com sent yesterday.
 They wrote: "Hey, let's connect our Claudes!"
 
 Would you like me to:
-1. Accept (I'll update your authz with read + conversation write access and sync)
-2. Reject (I'll delete the request)
+1. Accept (I'll run: claudeconnect accept-friend alice@example.com)
+2. Reject (I'll run: claudeconnect reject-friend alice@example.com)
 3. Ignore for now
 ```
 


### PR DESCRIPTION
## Summary
- Adds `claudeconnect accept-friend <email>` command that accepts a friend request, updates authz, and syncs to server automatically
- Adds `claudeconnect reject-friend <email>` command that rejects by deleting the request file and syncing
- Updates SKILL.md to document and use these commands instead of manual authz editing

~~Fixes #15~~

**Closing - this fixed the wrong issue. The actual bug was in the `friend` command (sender side), not the accept flow. See PR #18 for the correct fix.**