### PR TITLE
Fix friend command to abort if authz sync fails

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -989,7 +989,10 @@ def friend(peer_email: str, message: str):
 
     repo_url = repo_url_for_email(my_email)
     print("  Syncing authz changes...")
-    sync_once(context_dir, repo_url, svn_token, my_email)
+    if not sync_once(context_dir, repo_url, svn_token, my_email):
+        print("  Failed to sync authz changes to server")
+        print("  Friend request NOT sent. Please try again.")
+        sys.exit(1)
 
     # Step 3: Send friend request via API
     print("  Sending friend request...")


### PR DESCRIPTION
## Summary
Checks the return value of `sync_once()` in the `friend` command and aborts if sync fails.

Fixes #15

## Problem
When sending a friend request with `claudeconnect friend`, the command:
1. Updates local authz to grant the recipient access
2. Calls `sync_once()` to push authz to server
3. Sends friend request via API

The bug was that step 2 **ignored the return value** of `sync_once()`. If the sync failed for any reason (network issue, SVN error, etc.), the command would still proceed to send the friend request.

This caused the state described in #15: Marianne sent a friend request, Brandon accepted it, but Brandon couldn't access Marianne's context because her authz never made it to the server.

## Solution
Check if `sync_once()` returns `False` and abort with a clear error message before sending the friend request.

## Test plan
- [ ] Simulate sync failure and verify friend request is NOT sent
- [ ] Verify normal flow still works when sync succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)