### PR TITLE
Add post-init verification and improve error reporting

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -238,6 +238,50 @@ def install_skill() -> bool:
         return False
 
 
+def verify_init_structure(context_dir: Path) -> list[str]:
+    """
+    Verify that init created all expected directories and files.
+
+    Args:
+        context_dir: The context directory to verify
+
+    Returns:
+        List of error messages for missing/invalid components.
+        Empty list if everything is correct.
+    """
+    errors = []
+
+    # Check SVN working copy
+    svn_dir = context_dir / ".svn"
+    if not svn_dir.is_dir():
+        errors.append(".svn directory missing - not a valid SVN working copy")
+
+    # Check claudeconnect directory structure
+    cc_dir = context_dir / "claudeconnect"
+    if not cc_dir.is_dir():
+        errors.append("claudeconnect/ directory missing")
+    else:
+        fr_dir = cc_dir / "friend_requests"
+        if not fr_dir.is_dir():
+            errors.append("claudeconnect/friend_requests/ directory missing")
+
+        conv_dir = cc_dir / "conversations"
+        if not conv_dir.is_dir():
+            errors.append("claudeconnect/conversations/ directory missing")
+
+    # Check authz file
+    authz_file = context_dir / "authz"
+    if not authz_file.is_file():
+        errors.append("authz file missing")
+
+    # Check skill installation
+    skill_file = Path.home() / ".claude" / "skills" / "claudeconnect" / "SKILL.md"
+    if not skill_file.is_file():
+        errors.append("SKILL.md not installed at ~/.claude/skills/claudeconnect/")
+
+    return errors
+
+
 def migrate_authz_paths(authz_path: Path, email: str) -> bool:
     """
     Migrate old authz paths to new claudeconnect/ prefix.
@@ -741,6 +785,17 @@ def init():
         # Install skill for Claude Code
         if install_skill():
             print("  Installed claudeconnect skill")
+        else:
+            print("  Warning: Could not install claudeconnect skill")
+            print("    You may need to manually copy SKILL.md to ~/.claude/skills/claudeconnect/")
+
+        # Verify directory structure was created correctly
+        verification_errors = verify_init_structure(cwd)
+        if verification_errors:
+            print("\n⚠ Warning: Some components were not set up correctly:")
+            for error in verification_errors:
+                print(f"    - {error}")
+            print("  You may need to run `claudeconnect init` again or create these manually.")
 
         print("\n✓ Context directory initialized")
         print(f"  Run `claudeconnect` to start Claude with sync.")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -193,3 +193,105 @@ class TestDirectoryStructure:
         root_section = authz_content[:root_section_end]
         assert f"{test_user} = rw" in root_section, \
             "User should have rw on root section"
+
+
+class TestVerifyInitStructure:
+    """Tests for the verify_init_structure function."""
+
+    def test_verify_passes_after_valid_init(self, test_context):
+        """Verify that verify_init_structure returns no errors after valid init."""
+        context_dir, test_user = test_context
+
+        # Import the verification function
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        errors = verify_init_structure(context_dir)
+
+        # Should have no errors (except possibly skill, which is tested separately)
+        dir_errors = [e for e in errors if "SKILL.md" not in e]
+        assert len(dir_errors) == 0, f"Unexpected errors: {dir_errors}"
+
+    def test_verify_detects_missing_svn(self, tmp_path):
+        """Verify detection of missing .svn directory."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        # Create a directory without .svn
+        context_dir = tmp_path / "no_svn"
+        context_dir.mkdir()
+
+        errors = verify_init_structure(context_dir)
+
+        assert any(".svn" in e for e in errors), "Should detect missing .svn"
+
+    def test_verify_detects_missing_claudeconnect_dir(self, tmp_path):
+        """Verify detection of missing claudeconnect directory."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        # Create directory with .svn but no claudeconnect/
+        context_dir = tmp_path / "no_cc"
+        context_dir.mkdir()
+        (context_dir / ".svn").mkdir()
+
+        errors = verify_init_structure(context_dir)
+
+        assert any("claudeconnect/" in e for e in errors), "Should detect missing claudeconnect dir"
+
+    def test_verify_detects_missing_friend_requests(self, tmp_path):
+        """Verify detection of missing friend_requests directory."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        # Create directory structure missing friend_requests
+        context_dir = tmp_path / "no_fr"
+        context_dir.mkdir()
+        (context_dir / ".svn").mkdir()
+        (context_dir / "claudeconnect").mkdir()
+        (context_dir / "claudeconnect" / "conversations").mkdir()
+        (context_dir / "authz").write_text("[/]\ntest@test.com = rw\n")
+
+        errors = verify_init_structure(context_dir)
+
+        assert any("friend_requests" in e for e in errors), "Should detect missing friend_requests"
+
+    def test_verify_detects_missing_conversations(self, tmp_path):
+        """Verify detection of missing conversations directory."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        # Create directory structure missing conversations
+        context_dir = tmp_path / "no_conv"
+        context_dir.mkdir()
+        (context_dir / ".svn").mkdir()
+        (context_dir / "claudeconnect").mkdir()
+        (context_dir / "claudeconnect" / "friend_requests").mkdir()
+        (context_dir / "authz").write_text("[/]\ntest@test.com = rw\n")
+
+        errors = verify_init_structure(context_dir)
+
+        assert any("conversations" in e for e in errors), "Should detect missing conversations"
+
+    def test_verify_detects_missing_authz(self, tmp_path):
+        """Verify detection of missing authz file."""
+        import sys
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from claudeconnect.cli import verify_init_structure
+
+        # Create directory structure without authz
+        context_dir = tmp_path / "no_authz"
+        context_dir.mkdir()
+        (context_dir / ".svn").mkdir()
+        (context_dir / "claudeconnect").mkdir()
+        (context_dir / "claudeconnect" / "friend_requests").mkdir()
+        (context_dir / "claudeconnect" / "conversations").mkdir()
+
+        errors = verify_init_structure(context_dir)
+
+        assert any("authz" in e for e in errors), "Should detect missing authz"


### PR DESCRIPTION
## Summary

Fixes #21: Homebrew install directory structure and skill not set up correctly on init

**The problem:** When `claudeconnect init` failed to create directories or install the skill, users received no warning. The skill installation failure was completely silent — there was no `else` clause to print a warning when `install_skill()` returned `False`.

**The fix:**
- Add `verify_init_structure()` function that checks all expected artifacts exist after init
- Print explicit warning when skill installation fails
- Show clear list of any missing components so users know exactly what went wrong

## Changes

### `cli.py`
- Added `verify_init_structure(context_dir)` function that verifies:
  - `.svn` directory exists
  - `claudeconnect/` directory exists  
  - `claudeconnect/friend_requests/` directory exists
  - `claudeconnect/conversations/` directory exists
  - `authz` file exists
  - `~/.claude/skills/claudeconnect/SKILL.md` is installed
- Added `else` clause to print warning when `install_skill()` fails
- Call verification after init and display any errors found

### `tests/test_repository.py`
- Added `TestVerifyInitStructure` class with 6 tests:
  - `test_verify_passes_after_valid_init`
  - `test_verify_detects_missing_svn`
  - `test_verify_detects_missing_claudeconnect_dir`
  - `test_verify_detects_missing_friend_requests`
  - `test_verify_detects_missing_conversations`
  - `test_verify_detects_missing_authz`

## User-facing change

After init, if something fails, users now see:
```
⚠ Warning: Some components were not set up correctly:
    - claudeconnect/friend_requests/ directory missing
    - SKILL.md not installed at ~/.claude/skills/claudeconnect/
  You may need to run `claudeconnect init` again or create these manually.
```

## Test plan

- [x] All 6 new verification tests pass
- [x] All 9 existing init tests pass
- [ ] Manual test: Run `claudeconnect init` on fresh directory and verify no warnings
- [ ] Manual test: Manually break init (e.g., remove a directory) and verify warning appears

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)