### PR TITLE
Add visual dashboard with Claude creatures banner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ packages = ["src/claudeconnect"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/claudeconnect/skills/SKILL.md" = "claudeconnect/skills/SKILL.md"
+"src/claudeconnect/skills/commands/cc-status.md" = "claudeconnect/skills/commands/cc-status.md"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/cc-startup-hook.sh
+++ b/scripts/cc-startup-hook.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# ClaudeConnect startup hook - displays dashboard with status
+# Can be run anytime to show current status
+
+# Colors matching the Python CLI
+CORAL='\033[38;5;209m'
+LIME='\033[38;5;114m'
+WHITE='\033[97m'
+BOLD='\033[1m'
+DIM='\033[2m'
+BLACK_BG='\033[40m'
+YELLOW='\033[38;5;228m'
+RESET='\033[0m'
+
+# Context directory
+CONTEXT_DIR="${CLAUDE_CONTEXT_DIR:-$HOME/claude}"
+FRIEND_REQUESTS_DIR="$CONTEXT_DIR/claudeconnect/friend_requests"
+CONVERSATIONS_DIR="$CONTEXT_DIR/claudeconnect/conversations"
+
+# Get email from config
+EMAIL="you@example.com"
+if [ -f "$HOME/.config/claudeconnect/tokens.json" ]; then
+    EMAIL=$(grep -o '"email"[[:space:]]*:[[:space:]]*"[^"]*"' "$HOME/.config/claudeconnect/tokens.json" 2>/dev/null | cut -d'"' -f4)
+fi
+
+# Banner with sparkles
+echo ""
+echo -e " ${BLACK_BG}${CORAL}▐▛███▜▌${RESET} ${YELLOW}✦${RESET} ${BLACK_BG}${LIME}▐▛███▜▌${RESET}   ${WHITE}${BOLD}Claude Connect${RESET}"
+echo -e "${CORAL}▝▜█████▛▘${RESET}  ${LIME}▝▜█████▛▘${RESET}  ${DIM}${EMAIL}${RESET}"
+echo -e "  ${CORAL}▘▘ ▝▝${RESET}      ${LIME}▘▘ ▝▝${RESET}"
+echo ""
+
+# Box width
+W=34
+
+# Helper function to make boxes
+make_box_header() {
+    local title="$1"
+    local title_len=${#title}
+    local dashes=$((W - 5 - title_len))
+    printf "┌─ %s " "$title"
+    for ((i=0; i<dashes; i++)); do printf "─"; done
+    printf "┐\n"
+}
+
+make_box_item() {
+    local content="$1"
+    local content_len=${#content}
+    local max_len=$((W - 4))
+    if [ $content_len -gt $max_len ]; then
+        content="${content:0:$((max_len-3))}..."
+        content_len=$max_len
+    fi
+    local padding=$((max_len - content_len))
+    printf "│ %s" "$content"
+    for ((i=0; i<padding; i++)); do printf " "; done
+    printf " │\n"
+}
+
+make_box_footer() {
+    printf "└"
+    for ((i=0; i<W-2; i++)); do printf "─"; done
+    printf "┘\n"
+}
+
+# Count friend requests
+FR_COUNT=0
+FR_ITEMS=()
+if [ -d "$FRIEND_REQUESTS_DIR" ]; then
+    for f in "$FRIEND_REQUESTS_DIR"/*.md 2>/dev/null; do
+        [ -f "$f" ] || continue
+        if grep -q "status: pending" "$f" 2>/dev/null; then
+            sender=$(grep "^from:" "$f" 2>/dev/null | head -1 | cut -d: -f2 | tr -d ' ')
+            if [ -n "$sender" ]; then
+                FR_ITEMS+=("∙ $sender")
+                ((FR_COUNT++))
+            fi
+        fi
+    done
+fi
+
+# Check for accepted friend notifications
+if [ -d "$CONVERSATIONS_DIR" ]; then
+    for conv_dir in "$CONVERSATIONS_DIR"/with-*; do
+        [ -d "$conv_dir" ] || continue
+        accepted_file="$conv_dir/friend-accepted.md"
+        if [ -f "$accepted_file" ]; then
+            if grep -qi "friend-request-accepted" "$accepted_file" 2>/dev/null; then
+                email_line=$(grep -E "From:|\\*\\*From\\*\\*:" "$accepted_file" 2>/dev/null | head -1)
+                email_part=$(echo "$email_line" | cut -d: -f2 | tr -d ' *')
+                username=$(echo "$email_part" | cut -d@ -f1)
+                if [ -n "$username" ]; then
+                    FR_ITEMS+=("∙ $username accepted your request!")
+                    ((FR_COUNT++))
+                fi
+            fi
+        fi
+    done
+fi
+
+# Get recent conversations
+CONV_ITEMS=()
+if [ -d "$CONVERSATIONS_DIR" ]; then
+    month_ago=$(date -v-30d +%s 2>/dev/null || date -d "30 days ago" +%s 2>/dev/null)
+    for conv_dir in "$CONVERSATIONS_DIR"/with-*; do
+        [ -d "$conv_dir" ] || continue
+        dir_name=$(basename "$conv_dir")
+        peer_name="${dir_name#with-}"
+        # Convert to email format
+        peer_email="${peer_name//-/.}"
+
+        # Find most recent .md file (not friend-accepted.md)
+        latest_file=""
+        latest_time=0
+        for f in "$conv_dir"/*.md; do
+            [ -f "$f" ] || continue
+            [ "$(basename "$f")" = "friend-accepted.md" ] && continue
+            mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null)
+            if [ "$mtime" -gt "$latest_time" ]; then
+                latest_time=$mtime
+                latest_file=$f
+            fi
+        done
+
+        if [ -n "$latest_file" ] && [ "$latest_time" -gt "$month_ago" ]; then
+            topic=$(grep "^\*\*Topic\*\*:" "$latest_file" 2>/dev/null | head -1 | cut -d: -f2 | tr -d ' ')
+            username=$(echo "$peer_email" | cut -d@ -f1 | cut -d. -f1)
+            if [ -n "$topic" ]; then
+                CONV_ITEMS+=("∙ $username: $topic")
+            else
+                CONV_ITEMS+=("∙ $username")
+            fi
+        fi
+    done
+fi
+
+# Print boxes
+if [ ${#FR_ITEMS[@]} -gt 0 ] || [ ${#CONV_ITEMS[@]} -gt 0 ]; then
+    # Create friend requests box
+    if [ ${#FR_ITEMS[@]} -gt 0 ]; then
+        echo -n " "
+        make_box_header "FRIEND REQUESTS ($FR_COUNT)"
+        for item in "${FR_ITEMS[@]:0:5}"; do
+            echo -n " "
+            make_box_item "$item"
+        done
+        echo -n " "
+        make_box_footer
+    fi
+
+    # Create conversations box
+    if [ ${#CONV_ITEMS[@]} -gt 0 ]; then
+        echo -n " "
+        make_box_header "CONVERSATIONS"
+        for item in "${CONV_ITEMS[@]:0:5}"; do
+            echo -n " "
+            make_box_item "$item"
+        done
+        echo -n " "
+        make_box_footer
+    fi
+
+    echo ""
+fi

--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -6,6 +6,7 @@ Main entry point for the claudeconnect command.
 from __future__ import annotations
 
 import asyncio
+import datetime
 import shutil
 import subprocess
 import sys
@@ -14,6 +15,18 @@ from pathlib import Path
 
 import click
 import httpx
+
+# ANSI color codes - matching Claude Code's aesthetic
+CORAL = '\033[38;5;209m'      # Coral/salmon matching Claude Code
+LIME = '\033[38;5;114m'       # Muted lime green for friend Claude
+WHITE = '\033[97m'            # Bright white for main text
+BOLD = '\033[1m'              # Bold text
+DIM = '\033[2m'               # Dim for secondary text
+BLACK = '\033[30m'            # Black for eyes
+BLACK_BG = '\033[40m'         # Black background for transparency
+YELLOW = '\033[38;5;228m'     # Soft yellow for sparkles
+RESET = '\033[0m'
+CLEAR = '\033[2J\033[H'       # Clear screen and move cursor to top
 
 from .auth import login as do_login, ensure_valid_token, decode_jwt_payload, refresh_token
 from .config import (
@@ -27,6 +40,177 @@ from .sync import SyncLoop, sync_once
 
 
 SERVER_URL = "https://v2.claudeconnect.io"
+
+
+def display_startup_banner(context_dir: Path, email: str, clear_screen: bool = True) -> None:
+    """Display ClaudeConnect startup banner with two Claude creatures and status."""
+    # Clear screen for clean display (optional)
+    if clear_screen:
+        print(CLEAR, end='')
+
+    # Two Claude creatures side by side - coral (you) and lime (friend)
+    print()
+    print(f" {CORAL}▐{BLACK_BG}▛███▜{RESET}{CORAL}▌{RESET} {YELLOW}✦{RESET} {LIME}▐{BLACK_BG}▛███▜{RESET}{LIME}▌{RESET}   {WHITE}{BOLD}Claude Connect{RESET}")
+    print(f"{CORAL}▝▜█████▛▘{RESET} {LIME}▝▜█████▛▘{RESET}  {DIM}{email}{RESET}")
+    print(f"  {CORAL}▘▘ ▝▝{RESET}     {LIME}▘▘ ▝▝{RESET}")
+    print()
+
+    # Check for friend requests and conversations
+    friend_requests_dir = context_dir / "claudeconnect" / "friend_requests"
+    conversations_dir = context_dir / "claudeconnect" / "conversations"
+
+    # Collect friend request notifications (pending requests + accepted notifications)
+    friend_notifications = []  # List of (display_text, is_accepted)
+
+    if friend_requests_dir.exists():
+        for f in friend_requests_dir.glob("*.md"):
+            try:
+                content = f.read_text()
+                # Check for pending requests
+                if "status: pending" in content:
+                    for line in content.split("\n"):
+                        if line.startswith("from:"):
+                            sender = line.split(":", 1)[1].strip()
+                            friend_notifications.append((sender, False))
+                            break
+            except Exception:
+                pass
+
+    # Check conversations for accepted friend requests
+    accepted_friends = []
+    if conversations_dir.exists():
+        for conv_dir in conversations_dir.iterdir():
+            if conv_dir.is_dir() and conv_dir.name.startswith("with-"):
+                # Look for friend-accepted.md file
+                accepted_file = conv_dir / "friend-accepted.md"
+                if accepted_file.exists():
+                    try:
+                        content = accepted_file.read_text()
+                        if "friend-request-accepted" in content.lower():
+                            # Extract email from **From**: line
+                            for line in content.split("\n"):
+                                if "**From**:" in line or "From:" in line:
+                                    email_part = line.split(":", 1)[1].strip()
+                                    # Remove markdown bold if present
+                                    email_part = email_part.replace("**", "").strip()
+                                    accepted_friends.append(email_part)
+                                    break
+                    except Exception:
+                        pass
+
+    # Add accepted friends to notifications
+    for email_addr in accepted_friends:
+        # Extract username from email for shorter display
+        username = email_addr.split("@")[0] if "@" in email_addr else email_addr
+        friend_notifications.append((f"{username} accepted your request!", True))
+
+    # Get recent conversations (last 30 days) with topic preview
+    recent_convos = []  # List of (peer_email, topic_preview, mtime)
+    if conversations_dir.exists():
+        month_ago = datetime.datetime.now().timestamp() - (30 * 24 * 60 * 60)
+        for conv_dir in conversations_dir.iterdir():
+            if conv_dir.is_dir() and conv_dir.name.startswith("with-"):
+                peer_name = conv_dir.name[5:]  # Remove "with-" prefix
+                # Convert back to email format (replace - with . and @)
+                peer_email = peer_name.replace("-", ".")
+                # Fix common email pattern: user.example.com -> user@example.com
+                if peer_email.count(".") >= 2:
+                    parts = peer_email.rsplit(".", 2)
+                    if len(parts) == 3:
+                        peer_email = f"{parts[0]}@{parts[1]}.{parts[2]}"
+
+                latest_file = None
+                latest_time = 0
+                for f in conv_dir.glob("*.md"):
+                    # Skip friend-accepted.md files for conversation listing
+                    if f.name == "friend-accepted.md":
+                        continue
+                    try:
+                        mtime = f.stat().st_mtime
+                        if mtime > latest_time:
+                            latest_time = mtime
+                            latest_file = f
+                    except Exception:
+                        pass
+
+                if latest_file and latest_time > month_ago:
+                    # Extract topic from file
+                    topic = ""
+                    try:
+                        content = latest_file.read_text()
+                        for line in content.split("\n"):
+                            if line.startswith("**Topic**:"):
+                                topic = line.split(":", 1)[1].strip()
+                                break
+                    except Exception:
+                        pass
+                    recent_convos.append((peer_email, topic, latest_time))
+
+        # Sort by most recent
+        recent_convos.sort(key=lambda x: x[2], reverse=True)
+        recent_convos = recent_convos[:5]  # Limit to 5
+
+    # Display boxes side by side if there's activity
+    if friend_notifications or recent_convos:
+        W = 34  # Total box width
+
+        def truncate_with_ellipsis(text: str, max_len: int) -> str:
+            """Truncate text with ellipsis if it exceeds max_len."""
+            if len(text) <= max_len:
+                return text
+            return text[:max_len - 3] + "..."
+
+        def make_box(title: str, items: list[str]) -> list[str]:
+            """Create a box with title and items, exactly W chars wide."""
+            lines = []
+            # Header: ┌─ TITLE ───────┐
+            title_truncated = truncate_with_ellipsis(title, W - 6)
+            dashes = W - 5 - len(title_truncated)
+            lines.append(f"┌─ {title_truncated} " + "─" * dashes + "┐")
+            # Items: │ content      │
+            max_content_len = W - 4  # 2 for "│ " and 2 for " │"
+            for item in items:
+                content = truncate_with_ellipsis(item, max_content_len)
+                padding = max_content_len - len(content)
+                lines.append(f"│ {content}" + " " * padding + " │")
+            # Footer
+            lines.append("└" + "─" * (W - 2) + "┘")
+            return lines
+
+        fr_lines = []
+        if friend_notifications:
+            items = [f"∙ {notif[0]}" for notif in friend_notifications[:5]]
+            total = len(friend_notifications)
+            fr_lines = make_box(f"FRIEND REQUESTS ({total})", items)
+
+        conv_lines = []
+        if recent_convos:
+            items = []
+            for peer_email, topic, _ in recent_convos:
+                # Show email + topic preview
+                username = peer_email.split("@")[0] if "@" in peer_email else peer_email
+                if topic:
+                    items.append(f"∙ {username}: {topic}")
+                else:
+                    items.append(f"∙ {username}")
+            conv_lines = make_box("CONVERSATIONS", items)
+
+        # Print side by side or single
+        if fr_lines and conv_lines:
+            max_lines = max(len(fr_lines), len(conv_lines))
+            empty_space = " " * W
+            for i in range(max_lines):
+                left = fr_lines[i] if i < len(fr_lines) else empty_space
+                right = conv_lines[i] if i < len(conv_lines) else empty_space
+                print(f" {left}  {right}")
+        elif fr_lines:
+            for line in fr_lines:
+                print(f" {line}")
+        elif conv_lines:
+            for line in conv_lines:
+                print(f" {line}")
+
+        print()
 
 
 def get_svn_token(id_token: str) -> str | None:
@@ -599,6 +783,27 @@ def status():
 
 
 @cli.command()
+def dashboard():
+    """Show ClaudeConnect dashboard with friend requests and conversations."""
+    tokens = get_valid_token()
+    if not tokens:
+        print("Not logged in. Run `claudeconnect login` first.")
+        sys.exit(1)
+
+    config = get_config()
+    if not config.context_dir:
+        print("No context directory set. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    context_dir = Path(config.context_dir)
+    if not context_dir.exists():
+        print(f"Context directory not found: {context_dir}")
+        sys.exit(1)
+
+    display_startup_banner(context_dir, tokens.email, clear_screen=False)
+
+
+@cli.command()
 def start():
     """Start Claude with sync enabled (default command)."""
     # Check login and token validity
@@ -665,9 +870,12 @@ def start():
     print("\nSyncing...")
     sync_once(context_dir, repo_url, svn_token, tokens.email)
 
+    # Display startup banner with friend requests and conversations
+    display_startup_banner(context_dir, tokens.email)
+
     # Start sync loop and Claude
-    print("\nStarting Claude Code with sync enabled...")
-    print("(Sync runs every 30 seconds in background)\n")
+    print("Starting Claude Code with sync enabled...")
+    print(f"{DIM}(Sync runs every 30 seconds in background){RESET}\n")
 
     # Run async main
     asyncio.run(run_with_sync(context_dir, repo_url, svn_token, tokens.email))

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -59,6 +59,18 @@ claudeconnect login      # Authenticate with Google OAuth
 claudeconnect status     # Show current login status and repo info
 ```
 
+### Dashboard
+
+```bash
+claudeconnect dashboard  # Show pretty dashboard with friend requests & conversations
+```
+
+When the user asks to see their ClaudeConnect status, friend requests, or conversations dashboard, run `claudeconnect dashboard`. This displays:
+- Two Claude creatures with sparkles
+- Pending friend requests
+- "X accepted your request!" notifications
+- Active conversations with topic previews
+
 ### Syncing
 
 ```bash

--- a/src/claudeconnect/skills/commands/cc-status.md
+++ b/src/claudeconnect/skills/commands/cc-status.md
@@ -1,0 +1,17 @@
+# CC Status Command
+
+Show the ClaudeConnect dashboard with friend requests and conversations.
+
+## Instructions
+
+Run this command to display the dashboard:
+
+```bash
+claudeconnect dashboard
+```
+
+The dashboard shows:
+- Two Claude creatures with sparkles
+- Pending friend requests
+- "X accepted your request!" notifications
+- Active conversations with topic previews


### PR DESCRIPTION
## Summary
- Adds visual startup banner with two Claude creatures (coral + lime) connected by sparkles
- Friend requests box showing pending requests and accepted notifications
- Conversations box with recent activity and topic previews
- New `claudeconnect dashboard` command to show status without starting Claude
- ANSI colors matching Claude Code aesthetic

## Usage
```bash
claudeconnect dashboard    # Show dashboard
claudeconnect start        # Shows dashboard then starts Claude with sync
```

## Test plan
- [ ] Run `claudeconnect dashboard` - should show banner with friend requests/conversations boxes
- [ ] Run `claudeconnect start` - should display banner before starting sync
- [ ] Verify colors render correctly in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)