### PR TITLE
Fix SVN SQLite version mismatch on macOS with Homebrew

### DIFF
--- a/src/claudeconnect/svn_ops.py
+++ b/src/claudeconnect/svn_ops.py
@@ -78,7 +78,15 @@ class SvnClient:
         ]
 
         # Use system CA certs (fixes Homebrew OpenSSL not having Let's Encrypt roots)
-        env = {**os.environ, "SSL_CERT_FILE": "/etc/ssl/cert.pem"}
+        # DYLD_LIBRARY_PATH: On macOS, Homebrew's SVN may be compiled against a newer
+        # SQLite than the system provides, causing "SQLite compiled for X but running
+        # with Y" errors. Pointing to Homebrew's SQLite fixes this. Harmless on other
+        # systems (path ignored if it doesn't exist).
+        env = {
+            **os.environ,
+            "SSL_CERT_FILE": "/etc/ssl/cert.pem",
+            "DYLD_LIBRARY_PATH": "/opt/homebrew/opt/sqlite/lib",
+        }
 
         try:
             result = subprocess.run(


### PR DESCRIPTION
## Summary
- Set `DYLD_LIBRARY_PATH` to Homebrew's SQLite lib when running SVN commands
- Fixes "SQLite compiled for X but running with Y" errors on macOS when Homebrew's SVN is compiled against a newer SQLite than the system provides
- Harmless on other systems (non-existent paths are ignored)

## Test plan
- [x] `tests/test_authz.py::TestAuthzSync::test_authz_sync_to_svn` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)