### PR TITLE
Update build config: cryptography dependency + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ build/
 uv.lock
 
 # Generated directories
-mock-env/
+temp/
 .svn/
 .claude/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Connect contextualized Claude instances"
 requires-python = ">=3.9"
 dependencies = [
     "click>=8.0",
+    "cryptography>=41.0",
     "httpx>=0.25",
 ]
 


### PR DESCRIPTION
## Summary

- Add `cryptography>=41.0` to base dependencies (encryption is now default behavior)
- Update `.gitignore`: `temp/` instead of `mock-env/`

## Test plan

- [ ] Verify `pip install .` installs cryptography
- [ ] Verify temp/ directory is ignored

🤖 Generated with [Claude Code](https://claude.ai/claude-code)