### PR TITLE
Update server URL to claudeconnect.io

### DIFF
--- a/server/routes/oauth.py
+++ b/server/routes/oauth.py
@@ -19,7 +19,7 @@ GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
 # This server's base URL (for OAuth callback)
-SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "https://v2s.claudeconnect.io")
+SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "https://claudeconnect.io")
 
 
 @router.get("/login")

--- a/src/claudeconnect/config.py
+++ b/src/claudeconnect/config.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, asdict
 
 # Server configuration - single source of truth
 # Override with CLAUDECONNECT_SERVER environment variable
-DEFAULT_SERVER_URL = "https://v2s.claudeconnect.io"
+DEFAULT_SERVER_URL = "https://claudeconnect.io"
 SERVER_URL = os.environ.get("CLAUDECONNECT_SERVER", DEFAULT_SERVER_URL)
 API_BASE_URL = f"{SERVER_URL}/api"
 

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -7,7 +7,7 @@ ALICE_EMAIL = os.environ.get("CC_TEST_ALICE", "thisismysignupacct@gmail.com")
 BOB_EMAIL = os.environ.get("CC_TEST_BOB", "brandonduderstadt@gmail.com")
 
 # Server configuration
-SERVER = "v2s.claudeconnect.io"
+SERVER = "claudeconnect.io"
 SERVER_URL = f"https://{SERVER}"
 API_BASE_URL = f"{SERVER_URL}/api"
 


### PR DESCRIPTION
## Summary
- Update default server URL from `v2s.claudeconnect.io` to `claudeconnect.io`
- DNS migration complete - v2s server is now the main production server at claudeconnect.io

## Files Changed
- `src/claudeconnect/config.py` - Client default server URL
- `server/routes/oauth.py` - OAuth callback URL
- `tests/conf.py` - Test configuration

## Test plan
- [ ] Verify OAuth login flow works with new URL
- [ ] Run integration tests against claudeconnect.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)