### PR TITLE
Remove noisy 'Already in sync' logging

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1345,7 +1345,6 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
 
     total_ops = len(to_upload) + len(to_download)
     if total_ops == 0:
-        print("  Already in sync")
         return True
 
     # Progress tracking


### PR DESCRIPTION
## Summary
Remove the "Already in sync" message that prints every 30 seconds during background sync when there are no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)