### PR TITLE
Fix tests after pushing interactive mode

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1601,111 +1601,12 @@ def session(peer_email: str, topic: str | None, single: bool, turns: int):
         sys.exit(1)
 
 
-def pull_peer_context_http(peer_email: str, id_token: str, my_email: str, max_workers: int = 10) -> Path | None:
-    """Pull a peer's context using HTTP API (parallel downloads).
-
-    Saves to ~/.claude-connect/peers/<peer>/ for consistency with session.py.
-    """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-    import threading
-
-    # Save to PEERS_DIR (same location as session.py)
-    peer_name = email_to_repo_name(peer_email)
-    peer_dir = PEERS_DIR / peer_name
-    PEERS_DIR.mkdir(parents=True, exist_ok=True)
-    peer_dir.mkdir(parents=True, exist_ok=True)
-
-    headers = {"Authorization": f"Bearer {id_token}"}
-
-    # Get manifest from peer
-    try:
-        response = httpx.get(
-            f"{API_BASE_URL}/manifest/{peer_email}",
-            headers=headers,
-            timeout=60,
-        )
-        if response.status_code == 404:
-            print(f"  User {peer_email} not found")
-            return None
-        if response.status_code != 200:
-            print(f"  Failed to get manifest: {response.text}")
-            return None
-        manifest = response.json()
-    except Exception as e:
-        print(f"  Error getting manifest: {e}")
-        return None
-
-    files = manifest.get("files", [])
-    if not files:
-        print("  No files to download")
-        return peer_dir
-
-    # Progress tracking
-    completed = 0
-    downloaded = 0
-    skipped = 0
-    lock = threading.Lock()
-    total = len(files)
-
-    def download_file(file_info: dict) -> bool:
-        nonlocal completed, downloaded, skipped
-        path = file_info["path"]
-        try:
-            response = httpx.get(
-                f"{API_BASE_URL}/files/{peer_email}/{path}",
-                headers=headers,
-                timeout=60,
-            )
-            with lock:
-                completed += 1
-                pct = int(completed / total * 100)
-                if response.status_code == 200:
-                    local_path = peer_dir / path
-                    local_path.parent.mkdir(parents=True, exist_ok=True)
-                    local_path.write_bytes(response.content)
-                    downloaded += 1
-                    print(f"\r  [{pct:3d}%] Downloaded: {path[:50]:<50}", end="", flush=True)
-                    return True
-                elif response.status_code == 403:
-                    skipped += 1
-                    print(f"\r  [{pct:3d}%] Skipped (no access): {path[:40]:<40}", end="", flush=True)
-                    return False
-                else:
-                    print(f"\r  [{pct:3d}%] Failed ({response.status_code}): {path[:40]:<40}", end="", flush=True)
-                    return False
-        except Exception as e:
-            with lock:
-                completed += 1
-            return False
-
-    # Download in parallel
-    print(f"  Downloading {total} file(s) from {peer_email}...")
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [executor.submit(download_file, f) for f in files]
-        for future in as_completed(futures):
-            try:
-                future.result()
-            except Exception:
-                pass
-
-    print(f"\r  Downloaded {downloaded} file(s), skipped {skipped}" + " " * 30)
-
-    # Decrypt any encrypted files
-    try:
-        from .session import decrypt_peer_context
-        decrypted = decrypt_peer_context(peer_dir, peer_email)
-        if decrypted:
-            print(f"  Decrypted {decrypted} file(s)")
-    except Exception as e:
-        print(f"  Warning: Could not decrypt files: {e}")
-
-    return peer_dir
-
-
 @cli.command()
 @click.argument("peer_email")
 def pull(peer_email: str):
     """Pull a friend's context without starting a session."""
+    from .session import pull_peer_context_http
+
     tokens = get_valid_token()
     if not tokens:
         print("Not logged in or token expired. Run `claudeconnect login` first.")
@@ -2009,8 +1910,13 @@ def friend(peer_email: str):
             print(f"\n✗ User {peer_email} not found on ClaudeConnect")
             sys.exit(1)
         else:
-            data = response.json()
-            print(f"\n✗ Failed to send request: {data.get('error', 'Unknown error')}")
+            try:
+                data = response.json()
+                # FastAPI uses 'detail', others might use 'error'
+                error_msg = data.get('detail') or data.get('error') or 'Unknown error'
+            except Exception:
+                error_msg = response.text
+            print(f"\n✗ Failed to send request (HTTP {response.status_code}): {error_msg}")
             sys.exit(1)
 
     except Exception as e:

--- a/tests/test_big_vault.py
+++ b/tests/test_big_vault.py
@@ -17,24 +17,23 @@ Or standalone: python tests/test_big_vault.py
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import tempfile
 import shutil
 import time
-import httpx
 from pathlib import Path
-from dataclasses import dataclass, field
-from typing import Optional
+from dataclasses import dataclass
 
 import pytest
 
-from conf import ALICE_EMAIL, BOB_EMAIL, API_BASE_URL
-
-# Config directories
-CC_CONFIG_DIR = Path.home() / ".claude-connect"
-PEERS_DIR = CC_CONFIG_DIR / "peers"
+from conf import ALICE_EMAIL, BOB_EMAIL
+from test_utils import (
+    log, warn, error, timing,
+    clean_server, clean_client, claudeconnect,
+    get_current_email, email_to_repo_name, wait_for_user,
+    CC_CONFIG_DIR, PEERS_DIR, Colors,
+)
 
 # Test config
 NUM_VAULT_FILES = 500
@@ -84,139 +83,9 @@ class TimingStats:
         print("=" * 50)
 
 
-class Colors:
-    GREEN = "\033[0;32m"
-    YELLOW = "\033[1;33m"
-    RED = "\033[0;31m"
-    CYAN = "\033[0;36m"
-    MAGENTA = "\033[0;35m"
-    RESET = "\033[0m"
-
-
-def log(msg: str):
-    print(f"{Colors.GREEN}[TEST]{Colors.RESET} {msg}")
-
-
-def warn(msg: str):
-    print(f"{Colors.YELLOW}[WARN]{Colors.RESET} {msg}")
-
-
-def error(msg: str):
-    print(f"{Colors.RED}[ERROR]{Colors.RESET} {msg}")
-
-
-def prompt(msg: str):
-    print(f"{Colors.YELLOW}[ACTION REQUIRED]{Colors.RESET} {msg}")
-
-
-def timing(msg: str, seconds: float):
-    print(f"{Colors.MAGENTA}[TIMING]{Colors.RESET} {msg}: {seconds:.1f}s")
-
-
 def progress(current: int, total: int, msg: str):
+    """Print progress indicator."""
     print(f"{Colors.CYAN}[{current}/{total}]{Colors.RESET} {msg}")
-
-
-def run(cmd: list[str], cwd: Path | None = None, check: bool = True, input_text: str | None = None) -> subprocess.CompletedProcess:
-    """Run a command and return result."""
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, input=input_text)
-    if check and result.returncode != 0:
-        error(f"Command failed: {' '.join(cmd)}")
-        error(f"stdout: {result.stdout}")
-        error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed: {' '.join(cmd)}")
-    return result
-
-
-def claudeconnect(*args, cwd: Path | None = None, input_text: str | None = None, timeout: int = 600) -> subprocess.CompletedProcess:
-    """Run claudeconnect CLI command with extended timeout for large operations."""
-    result = subprocess.run(
-        ["claudeconnect", *args],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        input=input_text,
-        timeout=timeout,
-    )
-    if result.returncode != 0:
-        error(f"Command failed: claudeconnect {' '.join(args)}")
-        error(f"stdout: {result.stdout}")
-        error(f"stderr: {result.stderr}")
-        raise RuntimeError(f"Command failed: claudeconnect {' '.join(args)}")
-    return result
-
-
-def get_current_email() -> str:
-    """Get email from current tokens."""
-    tokens_file = CC_CONFIG_DIR / "tokens.json"
-    with open(tokens_file) as f:
-        return json.load(f)["email"]
-
-
-def get_id_token() -> str:
-    """Get ID token for API calls."""
-    tokens_file = CC_CONFIG_DIR / "tokens.json"
-    with open(tokens_file) as f:
-        return json.load(f)["id_token"]
-
-
-def email_to_repo_name(email: str) -> str:
-    """Convert email to repo name format."""
-    return email.replace("@", "-").replace(".", "-").lower()
-
-
-def wait_for_user(msg: str):
-    """Prompt user and wait for Enter."""
-    prompt(msg)
-    input("Press Enter to continue...")
-
-
-def clean_server():
-    """Remove test account data on server via HTTP API."""
-    log("Cleaning test account data on server...")
-
-    # We'll clean by deleting all files for test accounts
-    test_emails = [ALICE_EMAIL, BOB_EMAIL]
-
-    try:
-        tokens_file = CC_CONFIG_DIR / "tokens.json"
-        if tokens_file.exists():
-            token = get_id_token()
-            headers = {"Authorization": f"Bearer {token}"}
-
-            for email in test_emails:
-                # Get manifest and delete all files
-                try:
-                    response = httpx.get(
-                        f"{API_BASE_URL}/manifest/{email}",
-                        headers=headers,
-                        timeout=30,
-                    )
-                    if response.status_code == 200:
-                        manifest = response.json()
-                        files = manifest.get("files", [])
-                        if files:
-                            log(f"  Deleting {len(files)} files for {email}...")
-                            for f in files:
-                                httpx.delete(
-                                    f"{API_BASE_URL}/files/{email}/{f['path']}",
-                                    headers=headers,
-                                    timeout=30,
-                                )
-                except Exception as e:
-                    warn(f"  Could not clean {email}: {e}")
-    except Exception as e:
-        warn(f"Could not clean server (may not be logged in yet): {e}")
-
-    log("Server cleanup complete.")
-
-
-def clean_client():
-    """Remove local ~/.config/claudeconnect."""
-    log("Removing local claudeconnect config...")
-    if CC_CONFIG_DIR.exists():
-        shutil.rmtree(CC_CONFIG_DIR)
-    log("Local config removed.")
 
 
 def create_temp_dirs() -> tuple[Path, Path]:


### PR DESCRIPTION
## Summary
- Adds HTTP-based interactive sessions with Claude Code native transcript support
- Auto-discovers and imports transcripts from `~/.claude/projects/`
- Bidirectional sync: transcripts uploaded to both users' repos
- Fixes ANSI escape sequence bleeding, terminal rendering, and sync edge cases
- Refactors tests to use shared utilities

## Test plan
- [ ] Run `pytest tests/test_interactive_session.py` to verify interactive session flow
- [ ] Run `pytest tests/test_big_vault.py` to verify vault tests still pass
- [ ] Manual test: `claudeconnect interactive <peer>` opens Terminal with peer context

🤖 Generated with [Claude Code](https://claude.com/claude-code)