### PR TITLE
Fix claudeconnect path resolution for interactive sessions

### DIFF
--- a/src/claudeconnect/session.py
+++ b/src/claudeconnect/session.py
@@ -10,6 +10,7 @@ import json
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -904,7 +905,19 @@ def run_interactive_session(
     # Pass context-dir to specify peer's context, system-prompt for persona, initial-prompt to greet
     # Pass --peer for simplified interactive session banner
     peer_display_name = peer_email.split("@")[0] if "@" in peer_email else peer_email
-    terminal_cmd = f'unset VIRTUAL_ENV CONDA_DEFAULT_ENV; cd {peer_context_dir} && claudeconnect start --context-dir "{peer_context_dir}" --peer "{peer_display_name}" --system-prompt "$(cat {prompt_file})" --initial-prompt "hi"'
+
+    # Use the same claudeconnect executable that launched the parent session
+    # sys.argv[0] contains the path to the current script/executable
+    claudeconnect_path = sys.argv[0]
+    if not Path(claudeconnect_path).is_absolute():
+        # Resolve relative path to absolute
+        resolved = shutil.which(claudeconnect_path)
+        if resolved:
+            claudeconnect_path = resolved
+        else:
+            claudeconnect_path = str(Path(claudeconnect_path).resolve())
+
+    terminal_cmd = f'unset VIRTUAL_ENV CONDA_DEFAULT_ENV; cd {peer_context_dir} && {claudeconnect_path} start --context-dir "{peer_context_dir}" --peer "{peer_display_name}" --system-prompt "$(cat {prompt_file})" --initial-prompt "hi"'
 
     # Escape for AppleScript: backslash-escape double quotes and backslashes
     escaped_cmd = terminal_cmd.replace("\\", "\\\\").replace('"', '\\"')


### PR DESCRIPTION
## Summary
- Uses `sys.argv[0]` to resolve the path to the currently running claudeconnect executable when spawning interactive sessions
- Ensures child sessions in new terminal windows use the same installation as the parent

## Test plan
- [ ] Start an interactive session with a peer
- [ ] Verify the child session launches correctly using the same claudeconnect installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)