### PR TITLE
Add README and make sync output quiet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# ClaudeConnect
+
+Share context between Claude Code instances across machines. Your Claude can talk to your friends' Claudes.
+
+## Quick Start
+
+### 1. Install
+
+```bash
+git clone https://github.com/bstadt/cc_daemon.git
+cd cc_daemon
+pip install .
+```
+
+### 2. Pick a folder to share
+
+Choose a folder with markdown files, text notes, or other context you want Claude to know about. For your first try, pick something without private/sensitive content.
+
+Good options:
+- A notes folder with `.md` files
+- A personal knowledge base
+- Project documentation
+
+You can also create a fresh folder:
+
+```bash
+mkdir ~/claude-context
+echo "# About Me\n\nSome notes for Claude to know about." > ~/claude-context/about.md
+```
+
+### 3. Login and initialize
+
+```bash
+# Authenticate with Google
+claudeconnect login
+
+# Initialize ClaudeConnect in your chosen folder
+cd ~/your-notes-folder
+claudeconnect init
+```
+
+### 4. Start Claude with shared context
+
+```bash
+claudeconnect start
+```
+
+This launches Claude Code with your context synced. Any files in this folder become part of Claude's knowledge about you.
+
+## Adding Friends
+
+Once you're set up, you can connect with friends:
+
+```bash
+# Send a friend request
+claudeconnect friend their-email@gmail.com
+
+# Check status and pending requests
+claudeconnect status
+```
+
+When both of you have friended each other, your Claudes can share context and have conversations.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `claudeconnect login` | Authenticate with Google |
+| `claudeconnect init` | Initialize current folder as your context |
+| `claudeconnect start` | Launch Claude with synced context |
+| `claudeconnect status` | Show auth status and friend requests |
+| `claudeconnect friend <email>` | Send a friend request |
+| `claudeconnect sync` | Manually sync files |
+
+## Requirements
+
+- Python 3.9+
+- [Claude Code CLI](https://claude.ai/code) installed and authenticated
+
+## Troubleshooting
+
+**"Not logged in"**: Run `claudeconnect login` first.
+
+**"No context directory configured"**: Run `claudeconnect init` in the folder you want to use.
+
+**Sync issues**: Run `claudeconnect sync` to manually trigger a sync and see any errors.

--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1074,7 +1074,7 @@ def start(system_prompt: str | None, initial_prompt: str | None, context_dir: Pa
     # Initial sync using HTTP
     if not is_interactive:
         print("\nSyncing...")
-    if not sync_http(context_dir, tokens.email, tokens.id_token):
+    if not sync_http(context_dir, tokens.email, tokens.id_token, verbose=not is_interactive):
         if not is_interactive:
             print("  Sync failed")
         sys.exit(1)
@@ -1296,7 +1296,7 @@ def compute_bytes_sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 10) -> bool:
+def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 10, verbose: bool = False) -> bool:
     """Sync local files with server using HTTP API.
 
     Uses shadow directory for encrypted file storage and comparison.
@@ -1304,6 +1304,9 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     - Context dir contains plaintext versions (user's working copy)
     - Conflicts resolved by most recent mtime
     - Uploads and downloads run in parallel for speed
+
+    Args:
+        verbose: If True, print progress and summary. Default False for silent background sync.
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
     import threading
@@ -1409,9 +1412,10 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
         nonlocal completed
         with lock:
             completed += 1
-            pct = int(completed / total_ops * 100)
-            # Clear line and print progress
-            print(f"\r  [{pct:3d}%] {action}: {path[:60]:<60}", end="", flush=True)
+            if verbose:
+                pct = int(completed / total_ops * 100)
+                # Clear line and print progress
+                print(f"\r  [{pct:3d}%] {action}: {path[:60]:<60}", end="", flush=True)
 
     def upload_file(path: str, context_path: Path, shadow_path: Path) -> bool:
         """Upload a single file to server."""
@@ -1489,7 +1493,8 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
             return False
 
     # Step 5: Execute uploads and downloads in parallel
-    print(f"  Syncing {len(to_upload)} upload(s), {len(to_download)} download(s)...")
+    if verbose:
+        print(f"  Syncing {len(to_upload)} upload(s), {len(to_download)} download(s)...")
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []
@@ -1511,14 +1516,15 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
                     errors.append(str(e))
 
     # Clear progress line and print summary
-    print(f"\r  Downloaded {downloaded} file(s), uploaded {uploaded} file(s)" + " " * 40)
+    if verbose:
+        print(f"\r  Downloaded {downloaded} file(s), uploaded {uploaded} file(s)" + " " * 40)
 
-    if errors:
-        print(f"  Warnings ({len(errors)}):")
-        for err in errors[:5]:
-            print(f"    - {err}")
-        if len(errors) > 5:
-            print(f"    ... and {len(errors) - 5} more")
+        if errors:
+            print(f"  Warnings ({len(errors)}):")
+            for err in errors[:5]:
+                print(f"    - {err}")
+            if len(errors) > 5:
+                print(f"    ... and {len(errors) - 5} more")
 
     # Handle interactive session transcripts
     try:
@@ -1565,7 +1571,7 @@ def sync():
     context_dir = Path(config.context_dir)
 
     print("Syncing...")
-    if sync_http(context_dir, tokens.email, tokens.id_token):
+    if sync_http(context_dir, tokens.email, tokens.id_token, verbose=True):
         print("✓ Sync complete")
     else:
         sys.exit(1)


### PR DESCRIPTION
## Summary
- Add user-friendly README with installation and usage instructions for new users
- Add `verbose` parameter to `sync_http()`, defaults to `False`
- Background sync (every 30s) is now silent
- Explicit `claudeconnect sync` command still shows progress

## Test plan
- [ ] Verify `claudeconnect sync` shows progress output
- [ ] Verify background sync during `claudeconnect start` is silent
- [ ] Verify README instructions work for fresh install

🤖 Generated with [Claude Code](https://claude.ai/claude-code)