### PR TITLE
Filter out self-sent friend requests from display

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -216,6 +216,9 @@ def display_startup_banner(context_dir: Path, email: str, clear_screen: bool = T
                         if "**From**:" in line or "From:" in line:
                             sender = line.split(":", 1)[1].strip()
                             sender = sender.replace("**", "").strip()
+                            # Skip friend requests from yourself (shouldn't see own outgoing requests)
+                            if sender.lower() == email.lower():
+                                break
                             friend_notifications.append((sender, False))
                             break
             except Exception:


### PR DESCRIPTION
Fixes #73 (partial)

## Problem
On shared machines with multiple users, the friend request dialog can show:
1. Your own outgoing friend requests as incoming requests
2. Friend requests intended for other users on the machine

## Solution (client-side)
Filter out friend requests where the sender email matches the current user's email. This prevents users from seeing their own outgoing requests displayed as incoming.

## Limitations
This is a partial fix. The root cause appears to be that the sync is pulling friend request files that belong to other users' context directories. A complete fix would require:
- Server-side changes to properly isolate user data during sync, OR
- Adding a `**To**:` field to friend request files so the client can filter by intended recipient

## Test plan
- [ ] Run `claudeconnect` as user A who has sent a friend request
- [ ] Verify user A does not see their own outgoing request as an incoming request
- [ ] Test with multiple users on the same machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)