### PR TITLE
Fix: Ignore hidden files during sync

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1337,6 +1337,9 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     for file_path in shadow_dir.rglob("*"):
         if file_path.is_file():
             rel_path = str(file_path.relative_to(shadow_dir))
+            # Skip hidden files (any path component starting with '.')
+            if any(part.startswith('.') for part in Path(rel_path).parts):
+                continue
             shadow_files[rel_path] = {
                 "path": rel_path,
                 "sha256": compute_file_sha256(file_path),
@@ -1348,6 +1351,9 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     for file_path in context_dir.rglob("*"):
         if file_path.is_file():
             rel_path = str(file_path.relative_to(context_dir))
+            # Skip hidden files (any path component starting with '.')
+            if any(part.startswith('.') for part in Path(rel_path).parts):
+                continue
             context_files[rel_path] = {
                 "path": rel_path,
                 "mtime": file_path.stat().st_mtime,

--- a/src/claudeconnect/session.py
+++ b/src/claudeconnect/session.py
@@ -266,6 +266,9 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     for file_path in context_dir.rglob("*"):
         if file_path.is_file():
             rel_path = str(file_path.relative_to(context_dir))
+            # Skip hidden files (any path component starting with '.')
+            if any(part.startswith('.') for part in Path(rel_path).parts):
+                continue
             local_files[rel_path] = {
                 "path": rel_path,
                 "sha256": compute_sha256(file_path),


### PR DESCRIPTION
## Summary
- Skip files where any path component starts with `.` during sync
- Applies to both shadow directory and context directory traversals in `cli.py`
- Applies to session sync in `session.py`

This prevents syncing of `.DS_Store`, `.git/`, `.svn/`, editor swap files, and other hidden files that shouldn't be shared.

Fixes #80

## Test plan
- [ ] Run sync with a directory containing hidden files (e.g., `.DS_Store`, `.git/`)
- [ ] Verify hidden files are not uploaded
- [ ] Verify non-hidden files still sync correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)