### PR TITLE
Auto-accept reciprocal friend requests during sync

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1552,6 +1552,15 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
         # Silent failure - don't crash sync loop
         pass
 
+    # Auto-accept reciprocal friend requests (from people we already friended)
+    try:
+        accepted = auto_accept_reciprocal_requests(context_dir, email, id_token, verbose=verbose)
+        if accepted and verbose:
+            print(f"  Auto-accepted {accepted} reciprocal friend request(s)")
+    except Exception:
+        # Silent failure - don't crash sync loop
+        pass
+
     return True
 
 
@@ -2088,6 +2097,129 @@ def accept_friend(peer_email: str):
     print(f"\n✓ Friend request accepted!")
     print(f"  {peer_email} can now read your context and send you conversations.")
     print(f"  Pull their context with: claudeconnect pull {peer_email}")
+
+
+def auto_accept_reciprocal_requests(
+    context_dir: Path,
+    my_email: str,
+    id_token: str,
+    verbose: bool = False,
+) -> int:
+    """
+    Auto-accept friend requests from people we already initiated friendship with.
+
+    A "reciprocal" request is one where:
+    - We already sent them a friend request (they're in our authz)
+    - They accepted and sent their master key back to us
+
+    For these, we just need to extract their master key - no authz update needed.
+
+    Args:
+        context_dir: Path to context directory
+        my_email: Our email address
+        id_token: JWT for API calls
+        verbose: If True, print status messages
+
+    Returns:
+        Number of requests auto-accepted
+    """
+    import re
+
+    system_messages_dir = context_dir / "claudeconnect" / "with-claudeconnect-io"
+    if not system_messages_dir.exists():
+        return 0
+
+    # Load authz to check who we've already friended
+    authz_path = context_dir / "authz"
+    if not authz_path.exists():
+        return 0
+
+    authz_content = authz_path.read_text()
+
+    # Find all friend request files
+    request_files = list(system_messages_dir.glob("friend-request-*.md"))
+    if not request_files:
+        return 0
+
+    accepted_count = 0
+
+    for request_file in request_files:
+        try:
+            request_content = request_file.read_text()
+
+            # Extract sender's email from the request
+            from_match = re.search(r'\*\*From\*\*:\s*(\S+@\S+)', request_content)
+            if not from_match:
+                continue
+
+            peer_email = from_match.group(1).strip().lower()
+
+            # Check if this person is already in our authz (we initiated to them)
+            # They should have read access in [/] section
+            peer_has_access = f"{peer_email} = r" in authz_content or f"{peer_email} = rw" in authz_content
+
+            if not peer_has_access:
+                # Not a reciprocal request - needs manual acceptance
+                continue
+
+            # Check if we already have their master key
+            if HAS_ENCRYPTION and has_friend_master_key(peer_email, my_email):
+                # Already have their key, just clean up the request file
+                pass
+            elif HAS_ENCRYPTION:
+                # Extract and save their master key
+                master_key_match = re.search(r'\*\*Encrypted-Master-Key\*\*:\s*([a-fA-F0-9]+)', request_content)
+                if master_key_match:
+                    try:
+                        encrypted_master_key_hex = master_key_match.group(1)
+                        encrypted_blob = bytes.fromhex(encrypted_master_key_hex)
+                        friend_master_key = decrypt_received_master_key(encrypted_blob, my_email)
+                        save_friend_master_key(peer_email, friend_master_key, my_email)
+                        if verbose:
+                            print(f"  Auto-accepted reciprocal request from {peer_email} (got their master key)")
+                    except Exception as e:
+                        if verbose:
+                            print(f"  Warning: Could not decrypt master key from {peer_email}: {e}")
+                        continue
+                else:
+                    if verbose:
+                        print(f"  Auto-accepted reciprocal request from {peer_email} (no master key included)")
+
+                # Also save their public key if present
+                key_match = re.search(r'\*\*Public-Key\*\*:\s*([a-fA-F0-9]{64})', request_content)
+                if key_match:
+                    try:
+                        peer_public_key = bytes.fromhex(key_match.group(1))
+                        save_friend_public_key(peer_email, peer_public_key, my_email)
+                    except Exception:
+                        pass  # Non-fatal
+
+            # Delete the request file locally
+            try:
+                request_file.unlink()
+            except Exception:
+                pass
+
+            # Delete from server
+            try:
+                response = httpx.post(
+                    f"{API_BASE_URL}/accept-friend",
+                    headers={"Authorization": f"Bearer {id_token}"},
+                    json={"from_email": peer_email},
+                    timeout=30,
+                )
+                # Ignore response - best effort cleanup
+            except Exception:
+                pass
+
+            accepted_count += 1
+
+        except Exception as e:
+            if verbose:
+                print(f"  Warning: Error processing {request_file.name}: {e}")
+            continue
+
+    return accepted_count
 
 
 @cli.command("reject-friend")

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -55,7 +55,9 @@ from test_utils import (
     verify_file_access,
     verify_files_encrypted_on_server,
     verify_transcript_encrypted_on_server,
+    verify_peer_files_decrypted,
     pull_and_verify_poetry,
+    pull_peer_context,
     # Logging
     log,
 )
@@ -128,11 +130,16 @@ def test_full_flow(temp_dirs):
     verify_transcript("Alice", temp1, bob_email)
     pull_and_verify_poetry(temp1, bob_email)
 
-    # Bob verifies transcript
+    # Bob verifies transcript and can decrypt Alice's files
     os.chdir(temp2)
     login("Bob", temp2)
     init_account("Bob", temp2)
+    sync_files(temp2)  # Should auto-accept Alice's reciprocal request
     success = verify_transcript("Bob", temp2, alice_email)
+
+    # Verify Bob can pull and decrypt Alice's context
+    pull_peer_context(temp2, alice_email)
+    assert verify_peer_files_decrypted(alice_email), "Bob should be able to decrypt Alice's files"
 
     # Summary
     print()
@@ -198,15 +205,19 @@ def main():
 
         pull_and_verify_poetry(temp1, bob_email)
 
-        # Bob verifies transcript
+        # Bob verifies transcript and can decrypt Alice's files
         os.chdir(temp2)
         login("Bob", temp2)
         init_account("Bob", temp2)
-        sync_files(temp2)  # Pull transcript that Alice uploaded to Bob's repo
+        sync_files(temp2)  # Pull transcript + auto-accept Alice's reciprocal request
         verify_transcript("Bob", temp2, alice_email)
 
         # Verify Bob's copy of transcript is also encrypted on server
         verify_transcript_encrypted_on_server(bob_email, alice_email)
+
+        # Verify Bob can pull and decrypt Alice's context
+        pull_peer_context(temp2, alice_email)
+        assert verify_peer_files_decrypted(alice_email), "Bob should be able to decrypt Alice's files"
 
         log("==========================================")
         log("Integration test complete!")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -695,7 +695,7 @@ def verify_poetry(peer_email: str, expected_content: str = "widening gyre") -> b
 
 
 def verify_philosophy(peer_email: str) -> bool:
-    """Verify philosophy.md was pulled correctly."""
+    """Verify philosophy.md was pulled and decrypted correctly."""
     log("Verifying philosophy.md...")
 
     our_email = get_current_email()
@@ -707,10 +707,45 @@ def verify_philosophy(peer_email: str) -> bool:
         error(f"philosophy.md not found: {peer_philosophy}")
         return False
 
+    # Check file is NOT still encrypted (should be plaintext after pull)
+    raw_bytes = peer_philosophy.read_bytes()
+    if raw_bytes[:5] == CCENC_MAGIC:
+        error("philosophy.md is still encrypted! Decryption failed.")
+        return False
+    log("  ✓ File is decrypted (no CCENC header)")
+
     content = peer_philosophy.read_text()
     if "ineffability" in content:
-        log("philosophy.md verified - 'ineffability' found!")
+        log("  ✓ Content verified - 'ineffability' found!")
         return True
     else:
         error("philosophy.md verification failed - 'ineffability' not found")
         return False
+
+
+def verify_peer_files_decrypted(peer_email: str) -> bool:
+    """Verify that pulled peer files are decrypted (not still CCENC encrypted)."""
+    log(f"Verifying {peer_email}'s pulled files are decrypted...")
+
+    our_email = get_current_email()
+    peers_dir = get_peers_dir(our_email)
+    repo_name = email_to_repo_name(peer_email)
+    peer_dir = peers_dir / repo_name
+
+    if not peer_dir.exists():
+        error(f"Peer directory not found: {peer_dir}")
+        return False
+
+    md_files = list(peer_dir.rglob("*.md"))
+    if not md_files:
+        log("  No .md files found in peer context")
+        return True
+
+    for md_file in md_files:
+        raw_bytes = md_file.read_bytes()
+        if raw_bytes[:5] == CCENC_MAGIC:
+            error(f"  ✗ {md_file.name} is still encrypted!")
+            return False
+
+    log(f"  ✓ All {len(md_files)} .md files are decrypted")
+    return True


### PR DESCRIPTION
## Summary
- Adds `auto_accept_reciprocal_requests()` function that runs at the end of each sync
- Detects incoming friend requests from people already in your authz (meaning you initiated to them)
- Auto-extracts their master key and cleans up the request file
- No more manual `accept-friend` needed for reciprocal requests

## Test plan
- [ ] User A friends User B
- [ ] User B runs `accept-friend` for User A
- [ ] User A runs `sync` - should auto-accept B's reciprocal request
- [ ] User A's dashboard no longer shows "Friend request from B"
- [ ] User A can now `pull` and decrypt B's files

Fixes #77

🤖 Generated with [Claude Code](https://claude.ai/code)