### PR TITLE
Add unfriend and logout commands

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -125,7 +125,8 @@ from .config import (
     get_config, get_tokens, Config, Tokens, is_logged_in, get_email,
     get_test_user_email, get_test_user_credentials, list_test_users,
     TestUserCredentials, TEST_USERS_DIR, get_shadow_dir, sanitize_email,
-    SERVER_URL, API_BASE_URL, email_to_repo_name,
+    SERVER_URL, API_BASE_URL, email_to_repo_name, get_active_account,
+    get_tokens_file, get_config_file, ACTIVE_ACCOUNT_FILE, LEGACY_TOKENS_FILE,
 )
 from .scanner import scan_directory
 
@@ -895,6 +896,48 @@ def login():
     else:
         print(f"\n✗ Login failed: {result.error}")
         sys.exit(1)
+
+
+@cli.command()
+@click.option("--full", is_flag=True, help="Also remove local config for this account.")
+def logout(full: bool):
+    """Logout of Claude Connect and remove local credentials."""
+    active_email = get_active_account()
+    tokens = get_tokens()
+    if not active_email and tokens:
+        active_email = tokens.email
+    if not active_email and not LEGACY_TOKENS_FILE.exists():
+        print("Not logged in.")
+        return
+
+    print("Logging out of ClaudeConnect...")
+
+    if active_email:
+        tokens_file = get_tokens_file(active_email)
+        if tokens_file.exists():
+            tokens_file.unlink()
+            print(f"  Removed tokens for {active_email}")
+        else:
+            print(f"  No tokens found for {active_email}")
+        if full:
+            config_file = get_config_file(active_email)
+            if config_file.exists():
+                config_file.unlink()
+                print("  Removed config.json")
+            else:
+                print("  No config.json found")
+
+    if LEGACY_TOKENS_FILE.exists():
+        LEGACY_TOKENS_FILE.unlink()
+        print("  Removed legacy tokens.json")
+
+    if ACTIVE_ACCOUNT_FILE.exists():
+        ACTIVE_ACCOUNT_FILE.unlink()
+
+    if full:
+        print("\n✓ Logged out and cleared local configuration.")
+    else:
+        print("\n✓ Logged out. Run `claudeconnect login` to sign in again.")
 
 
 @cli.command()
@@ -1781,6 +1824,61 @@ def add_friend_to_authz(authz_path: Path, my_email: str, peer_email: str) -> boo
     return changes_made
 
 
+def remove_friend_from_authz(authz_path: Path, peer_email: str) -> bool:
+    """
+    Remove a friend's access from the authz file.
+
+    Removes:
+    - Read access from [/] section
+    - Write access from [/claudeconnect/with-{peer}] section
+    - Legacy write access from [/claudeconnect/conversations] if present
+
+    Args:
+        authz_path: Path to authz file
+        peer_email: Friend's email to remove
+
+    Returns:
+        True if changes were made, False otherwise.
+    """
+    authz_content = authz_path.read_text()
+    lines = authz_content.split('\n')
+    new_lines = []
+    changes_made = False
+
+    peer_email_repo_name = email_to_repo_name(peer_email)
+    peer_with_section = f"[/claudeconnect/with-{peer_email_repo_name}]"
+    legacy_section = "[/claudeconnect/conversations]"
+
+    current_section = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('['):
+            current_section = stripped
+
+        if current_section in ('[/]', peer_with_section, legacy_section):
+            if '=' in stripped:
+                left = stripped.split('=', 1)[0].strip()
+                if left == peer_email:
+                    if current_section == '[/]':
+                        print(f"  Removed {peer_email} read access from [/]")
+                    elif current_section == peer_with_section:
+                        print(f"  Removed {peer_email} write access from {peer_with_section}")
+                    else:
+                        print(f"  Removed {peer_email} write access from {legacy_section}")
+                    changes_made = True
+                    continue
+
+        new_lines.append(line)
+
+    if changes_made:
+        authz_path.write_text('\n'.join(new_lines))
+    else:
+        print(f"  {peer_email} not found in your authz")
+
+    return changes_made
+
+
 def fetch_peer_public_key(peer_email: str) -> bytes | None:
     """
     Fetch a peer's public key from the server API.
@@ -2099,6 +2197,47 @@ def accept_friend(peer_email: str):
 
     print(f"\n✓ Friend request accepted!")
     print(f"  {peer_email} can now read your context and send you conversations.")
+
+
+@cli.command()
+@click.argument("peer_email")
+def unfriend(peer_email: str):
+    """Remove a friend's access from your authz and sync the change."""
+    tokens = get_valid_token()
+    if not tokens:
+        print("Not logged in or token expired. Run `claudeconnect login` first.")
+        sys.exit(1)
+
+    config = get_config()
+    if not config.context_dir:
+        print("No context directory configured. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    peer_email = peer_email.strip().lower()
+    my_email = tokens.email
+
+    if peer_email == my_email:
+        print("Cannot unfriend yourself.")
+        sys.exit(1)
+
+    print(f"Removing {peer_email} from your friends...")
+
+    authz_path = Path(config.context_dir) / "authz"
+    if not authz_path.exists():
+        print("Error: authz file not found. Run `claudeconnect init` first.")
+        sys.exit(1)
+
+    if not remove_friend_from_authz(authz_path, peer_email):
+        print("  No changes needed.")
+        return
+
+    print("  Uploading authz changes...")
+    authz_content = authz_path.read_text()
+    if not upload_authz_http(tokens.id_token, my_email, authz_content):
+        print("Failed to upload authz")
+        sys.exit(1)
+
+    print(f"\n✓ {peer_email} can no longer access your context.")
     print(f"  Pull their context with: claudeconnect pull {peer_email}")
 
 

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -61,6 +61,7 @@ Running `claudeconnect` will:
 
 ```bash
 claudeconnect login      # Authenticate with Google OAuth
+claudeconnect logout     # Remove local credentials
 claudeconnect status     # Show current login status and repo info
 ```
 
@@ -100,6 +101,7 @@ When you send a friend request, your public key is included. When they accept, t
 claudeconnect friend <email>                   # Send friend request
 claudeconnect accept-friend <email>            # Accept incoming friend request
 claudeconnect reject-friend <email>            # Reject incoming friend request
+claudeconnect unfriend <email>                 # Remove a friend's access
 claudeconnect pull <email>                     # Pull friend's context locally
 claudeconnect session <email> [-t "topic"]     # Autonomous conversation (Claudes talk)
 claudeconnect session <email> --turns 10       # Set max conversation turns (default: 6)
@@ -166,6 +168,14 @@ claudeconnect reject-friend alice@example.com
 
 This deletes the request file and syncs without granting any access.
 
+### Removing a Friend
+
+Use the `unfriend` command to remove a friend's access:
+
+```bash
+claudeconnect unfriend alice@example.com
+```
+
 ## The authz File
 
 Controls who can read your context and write conversations:
@@ -190,7 +200,7 @@ owner@email.com = rw
 friend2@test.org = rw          # Another friend
 ```
 
-To remove a friend: delete their lines from `[/]` and their `/claudeconnect/with-<email>` section, then sync.
+To remove a friend: run `claudeconnect unfriend <email>`.
 
 ## Reading Friend Context
 

--- a/tests/test_authz_unfriend.py
+++ b/tests/test_authz_unfriend.py
@@ -1,0 +1,52 @@
+from claudeconnect.cli import remove_friend_from_authz
+
+
+def test_remove_friend_from_authz_removes_sections(tmp_path):
+    authz_path = tmp_path / "authz"
+    authz_path.write_text(
+        "\n".join(
+            [
+                "[/]",
+                "owner@example.com = rw",
+                "alice@example.com = r",
+                "",
+                "[/claudeconnect/with-alice-example-com]",
+                "owner@example.com = rw",
+                "alice@example.com = rw",
+                "",
+                "[/claudeconnect/with-bob-example-com]",
+                "owner@example.com = rw",
+                "bob@example.com = rw",
+            ]
+        )
+    )
+
+    changed = remove_friend_from_authz(authz_path, "alice@example.com")
+    assert changed is True
+
+    content = authz_path.read_text()
+    assert "alice@example.com" not in content
+    assert "bob@example.com = rw" in content
+
+
+def test_remove_friend_from_authz_handles_legacy_section(tmp_path):
+    authz_path = tmp_path / "authz"
+    authz_path.write_text(
+        "\n".join(
+            [
+                "[/]",
+                "owner@example.com = rw",
+                "carol@example.com = r",
+                "",
+                "[/claudeconnect/conversations]",
+                "owner@example.com = rw",
+                "carol@example.com = rw",
+            ]
+        )
+    )
+
+    changed = remove_friend_from_authz(authz_path, "carol@example.com")
+    assert changed is True
+
+    content = authz_path.read_text()
+    assert "carol@example.com" not in content


### PR DESCRIPTION
## Summary
- add `claudeconnect unfriend` to remove peer access from authz (root + with-<peer> + legacy section)
- add `claudeconnect logout` with optional `--full` config cleanup
- document new commands in SKILL.md
- add unit tests for authz unfriend removal

## Testing
- not run

Closes #35
Closes #36