### PR TITLE
Fix: remove accidental audit flow from cli

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -63,19 +63,6 @@ from .config import (
     get_tokens_file, get_config_file, ACTIVE_ACCOUNT_FILE, LEGACY_TOKENS_FILE,
     get_friends_dir, get_peers_dir,
 )
-from .audit import (
-    ensure_privacy_policy,
-    load_ignore_patterns,
-    append_ignore_patterns,
-    IgnoreMatcher,
-    iter_context_files,
-    is_text_file,
-    parse_paths_input,
-    run_llm_scan,
-    write_pending_sensitive,
-)
-from .scanner import scan_directory
-
 # Encryption is optional - only available if cryptography is installed
 try:
     from .encryption import (
@@ -842,171 +829,6 @@ def init_context_dir(
     return True
 
 
-def update_authz_private_files(authz_path: Path, owner_email: str, private_paths: list[str]) -> bool:
-    """Append private file sections to authz (owner-only access)."""
-    if not private_paths:
-        return False
-    if not authz_path.exists():
-        print("  Error: authz file not found.")
-        return False
-
-    content = authz_path.read_text().splitlines()
-    existing_sections = set()
-    for line in content:
-        line = line.strip()
-        if line.startswith("[") and line.endswith("]"):
-            existing_sections.add(line[1:-1])
-
-    new_sections: list[str] = []
-    for raw_path in private_paths:
-        if "*" in raw_path or "?" in raw_path:
-            print(f"  Skipping glob path for authz (not supported): {raw_path}")
-            continue
-        path = raw_path if raw_path.startswith("/") else "/" + raw_path
-        if path in existing_sections:
-            continue
-        new_sections.append(path)
-
-    if not new_sections:
-        return False
-
-    if content and content[-1].strip():
-        content.append("")
-    content.append("# Private files (added by audit)")
-    for path in new_sections:
-        content.append(f"[{path}]")
-        content.append(f"{owner_email} = rw")
-        content.append("")
-
-    authz_path.write_text("\n".join(content).rstrip() + "\n")
-    return True
-
-
-def prompt_for_paths(prompt: str) -> list[str]:
-    raw = input(prompt).strip()
-    return parse_paths_input(raw)
-
-
-def apply_private_files(authz_path: Path, owner_email: str, token: str, private_paths: list[str]) -> None:
-    if update_authz_private_files(authz_path, owner_email, private_paths):
-        if upload_authz_http(token, owner_email, authz_path.read_text()):
-            print("  Updated authz (private paths uploaded)")
-        else:
-            print("  Warning: Failed to upload updated authz")
-
-
-def run_llm_scan_flow(
-    context_dir: Path,
-    owner_email: str,
-    token: str,
-    ignore_matcher: IgnoreMatcher,
-    max_files: int | None = None,
-) -> None:
-    privacy_path = ensure_privacy_policy(context_dir)
-
-    candidates = [
-        path for path in iter_context_files(context_dir, ignore_matcher)
-        if path.name not in {"privacy.md"} and is_text_file(path)
-    ]
-
-    if not candidates:
-        print("No eligible text files found for LLM scan.")
-        return
-
-    print(f"Running LLM scan on {len(candidates)} files (Haiku subagents)...")
-    try:
-        results = run_llm_scan(context_dir, candidates, privacy_path, max_files=max_files).get("results", [])
-    except FileNotFoundError:
-        print("Error: 'claude' command not found. Install Claude Code CLI first.")
-        return
-    except Exception as e:
-        print(f"LLM scan failed: {e}")
-        return
-
-    if not results:
-        print("No LLM results returned.")
-        return
-
-    pending_dir = write_pending_sensitive(context_dir, owner_email, results)
-
-    flagged = [r for r in results if r.get("sensitive")]
-    print(f"LLM scan complete. Flagged {len(flagged)} file(s).")
-    if flagged:
-        for entry in flagged:
-            reason = entry.get("reason", "").strip()
-            if len(reason) > 120:
-                reason = reason[:117] + "..."
-            print(f"  - {entry.get('path')}: {reason}")
-        print(f"Pending results saved to: {pending_dir}")
-
-        raw_ignore = input("Paths to never upload (.ccignore) [comma-separated or 'all']: ").strip()
-        raw_private = input("Paths to restrict in authz [comma-separated or 'all']: ").strip()
-
-        if raw_ignore.lower() == "all":
-            ignore_paths = [e.get("path") for e in flagged if e.get("path")]
-        else:
-            ignore_paths = parse_paths_input(raw_ignore)
-
-        if raw_private.lower() == "all":
-            private_paths = [e.get("path") for e in flagged if e.get("path")]
-        else:
-            private_paths = parse_paths_input(raw_private)
-
-        if ignore_paths:
-            append_ignore_patterns(context_dir, ignore_paths)
-            print("  Updated .ccignore")
-
-        if private_paths:
-            authz_path = context_dir / "authz"
-            apply_private_files(authz_path, owner_email, token, private_paths)
-    else:
-        print(f"Pending results saved to: {pending_dir}")
-
-
-def run_sensitive_audit(context_dir: Path, owner_email: str, token: str) -> None:
-    print("\nSensitive File Audit")
-    print("-" * 24)
-    print("This flow helps you identify files that should be hidden or restricted.")
-
-    ignore_patterns = load_ignore_patterns(context_dir)
-    ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
-
-    hard_exclusions = prompt_for_paths(
-        "Directories/files to NEVER upload (.ccignore) [comma-separated, blank to skip]: "
-    )
-    if hard_exclusions:
-        ignore_patterns = append_ignore_patterns(context_dir, hard_exclusions)
-        ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
-        print("  Updated .ccignore with hard exclusions.")
-
-    print("\nRunning local regex scan (conservative)...")
-    report = scan_directory(context_dir, markdown_only=False, ignore_matcher=ignore_matcher)
-    if report.has_issues:
-        print(report.format_report(context_dir))
-        private_paths = prompt_for_paths(
-            "Files to restrict in authz [comma-separated, blank to skip]: "
-        )
-        if private_paths:
-            authz_path = context_dir / "authz"
-            apply_private_files(authz_path, owner_email, token, private_paths)
-
-        ignore_paths = prompt_for_paths(
-            "Files to NEVER upload (.ccignore) [comma-separated, blank to skip]: "
-        )
-        if ignore_paths:
-            ignore_patterns = append_ignore_patterns(context_dir, ignore_paths)
-            ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
-            print("  Updated .ccignore")
-    else:
-        print("No regex matches found.")
-
-    privacy_path = ensure_privacy_policy(context_dir)
-    if privacy_path.exists():
-        print(f"Privacy policy: {privacy_path}")
-
-    print("\nOptional: Run an LLM-based scan (sends file contents to the model provider).")
-    if click.confirm("Run LLM scan now?", default=False):
-        run_llm_scan_flow(context_dir, owner_email, token, ignore_matcher)
 
 
 @click.group(invoke_without_command=True)
@@ -1513,14 +1335,6 @@ def init(no_encrypt: bool):
                 print(f"    - {error}")
             print("  You may need to run `claudeconnect init` again or create these manually.")
 
-        privacy_path = cwd / "privacy.md"
-        if not privacy_path.exists():
-            ensure_privacy_policy(cwd)
-            print("  Created privacy.md (soft privacy policy).")
-
-        if click.confirm("\nWould you like to run a Sensitive File Audit now?", default=True):
-            run_sensitive_audit(cwd, tokens.email, tokens.id_token)
-
         print("\n✓ Context directory initialized")
         if encrypt:
             print("  Encryption: ENABLED (zero-trust)")
@@ -1565,9 +1379,6 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     config = get_config(email)
     encryption_enabled = config.encryption_enabled and HAS_ENCRYPTION
 
-    ignore_patterns = load_ignore_patterns(context_dir)
-    ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
-
     # Shadow directory stores encrypted files (mirrors server)
     shadow_dir = get_shadow_dir(email)
     shadow_dir.mkdir(parents=True, exist_ok=True)
@@ -1589,14 +1400,7 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
         print(f"  Error getting manifest: {e}")
         return False
 
-    server_files = {}
-    for f in manifest.get("files", []):
-        rel_path = f.get("path")
-        if not rel_path:
-            continue
-        if ignore_matcher.matches(context_dir / rel_path):
-            continue
-        server_files[rel_path] = f
+    server_files = {f["path"]: f for f in manifest.get("files", [])}
 
     # Step 2: Build shadow directory manifest (encrypted files)
     shadow_files = {}
@@ -1605,8 +1409,6 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
             rel_path = str(file_path.relative_to(shadow_dir))
             # Skip hidden files (any path component starting with '.')
             if any(part.startswith('.') for part in Path(rel_path).parts):
-                continue
-            if ignore_matcher.matches(context_dir / rel_path):
                 continue
             shadow_files[rel_path] = {
                 "path": rel_path,
@@ -1621,8 +1423,6 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
             rel_path = str(file_path.relative_to(context_dir))
             # Skip hidden files (any path component starting with '.')
             if any(part.startswith('.') for part in Path(rel_path).parts):
-                continue
-            if ignore_matcher.matches(file_path):
                 continue
             context_files[rel_path] = {
                 "path": rel_path,
@@ -1901,36 +1701,6 @@ def sync():
     else:
         sys.exit(1)
 
-
-@cli.command()
-@click.option("--llm", "llm_scan", is_flag=True, help="Run LLM-based scan (Haiku subagents)")
-@click.option("--max-files", type=int, default=None, help="Limit number of files for LLM scan")
-def scan(llm_scan: bool, max_files: int | None):
-    """Run a sensitive file audit (local regex or LLM-based)."""
-    tokens = get_valid_token()
-    config = get_config()
-
-    if not tokens:
-        print("Not logged in or token expired. Run `claudeconnect login` first.")
-        sys.exit(1)
-
-    if not config.context_dir:
-        print("No context directory configured. Run `claudeconnect init` first.")
-        sys.exit(1)
-
-    context_dir = Path(config.context_dir)
-    ignore_patterns = load_ignore_patterns(context_dir)
-    ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
-
-    if llm_scan:
-        print("LLM scan requested. This will send file contents to the model provider.")
-        if click.confirm("Continue?", default=False):
-            run_llm_scan_flow(context_dir, tokens.email, tokens.id_token, ignore_matcher, max_files=max_files)
-        else:
-            print("LLM scan cancelled.")
-        return
-
-    run_sensitive_audit(context_dir, tokens.email, tokens.id_token)
 
 @cli.command()
 @click.argument("peer_email")


### PR DESCRIPTION
## Summary
- remove privacy audit flow helpers and scan command from cli.py
- drop .audit imports and init prompts added by accident
- restore sync_http behavior without audit ignore matcher

## Testing
- not run (cli-only change)