### PR TITLE
Fix: skip uploads above size limit

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1379,6 +1379,17 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     config = get_config(email)
     encryption_enabled = config.encryption_enabled and HAS_ENCRYPTION
 
+    ignore_patterns = load_ignore_patterns(context_dir)
+    ignore_matcher = IgnoreMatcher(context_dir, ignore_patterns)
+    max_upload_mb = os.environ.get("CC_MAX_UPLOAD_MB", "").strip()
+    try:
+        max_upload_mb_value = float(max_upload_mb) if max_upload_mb else 1.0
+    except ValueError:
+        max_upload_mb_value = 1.0
+    max_upload_bytes = int(max_upload_mb_value * 1024 * 1024)
+
+    def is_hidden_path(rel_path: str) -> bool:
+        return any(part.startswith(".") for part in Path(rel_path).parts)
     # Shadow directory stores encrypted files (mirrors server)
     shadow_dir = get_shadow_dir(email)
     shadow_dir.mkdir(parents=True, exist_ok=True)
@@ -1400,7 +1411,16 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
         print(f"  Error getting manifest: {e}")
         return False
 
-    server_files = {f["path"]: f for f in manifest.get("files", [])}
+    server_files = {}
+    for f in manifest.get("files", []):
+        rel_path = f.get("path")
+        if not rel_path:
+            continue
+        if is_hidden_path(rel_path):
+            continue
+        if ignore_matcher.matches(context_dir / rel_path):
+            continue
+        server_files[rel_path] = f
 
     # Step 2: Build shadow directory manifest (encrypted files)
     shadow_files = {}
@@ -1409,6 +1429,8 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
             rel_path = str(file_path.relative_to(shadow_dir))
             # Skip hidden files (any path component starting with '.')
             if any(part.startswith('.') for part in Path(rel_path).parts):
+                continue
+            if ignore_matcher.matches(context_dir / rel_path):
                 continue
             shadow_files[rel_path] = {
                 "path": rel_path,
@@ -1423,6 +1445,8 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
             rel_path = str(file_path.relative_to(context_dir))
             # Skip hidden files (any path component starting with '.')
             if any(part.startswith('.') for part in Path(rel_path).parts):
+                continue
+            if ignore_matcher.matches(file_path):
                 continue
             context_files[rel_path] = {
                 "path": rel_path,
@@ -1475,6 +1499,7 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     # Step 4: Categorize files into upload/download lists
     to_upload = []  # (path, context_path, shadow_path)
     to_download = []  # (path, shadow_path, context_path, server_info)
+    skipped_large: list[tuple[str, int]] = []
 
     all_paths = set(server_files.keys()) | set(shadow_files.keys()) | set(context_files.keys())
 
@@ -1496,27 +1521,50 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
                 if shadow_info and context_matches_shadow(path, context_path, shadow_path):
                     to_download.append((path, shadow_path, context_path, server_info))
                 else:
-                    to_upload.append((path, context_path, shadow_path))
+                    if context_path.exists():
+                        size = context_path.stat().st_size
+                        if size > max_upload_bytes:
+                            skipped_large.append((path, size))
+                        else:
+                            to_upload.append((path, context_path, shadow_path))
             else:
                 # Server is newer - download
                 to_download.append((path, shadow_path, context_path, server_info))
 
         # Case 2: File exists locally but not on server - upload
         elif context_info and not server_info:
-            to_upload.append((path, context_path, shadow_path))
+            if context_path.exists():
+                size = context_path.stat().st_size
+                if size > max_upload_bytes:
+                    skipped_large.append((path, size))
+                else:
+                    to_upload.append((path, context_path, shadow_path))
 
         # Case 3: File in shadow matches server
         elif shadow_info and server_info and shadow_info["sha256"] == server_info["sha256"]:
             if context_info and context_info["mtime"] > shadow_info["mtime"]:
                 # Context changed - upload only if content changed
                 if not context_matches_shadow(path, context_path, shadow_path):
-                    to_upload.append((path, context_path, shadow_path))
+                    if context_path.exists():
+                        size = context_path.stat().st_size
+                        if size > max_upload_bytes:
+                            skipped_large.append((path, size))
+                        else:
+                            to_upload.append((path, context_path, shadow_path))
             elif not context_info:
                 # Context missing - decrypt from shadow to context
                 to_download.append((path, shadow_path, context_path, server_info))
 
     total_ops = len(to_upload) + len(to_download)
     if total_ops == 0:
+        if verbose and skipped_large:
+            print(f"  {len(skipped_large)} file(s) above size limit ({max_upload_mb_value:g}MB). Skipping upload.")
+            print(f"  Limit: {max_upload_mb_value:g}MB (override with CC_MAX_UPLOAD_MB)")
+            for path, size in skipped_large[:10]:
+                size_mb = size / (1024 * 1024)
+                print(f"    - {path} ({size_mb:.2f} MB)")
+            if len(skipped_large) > 10:
+                print(f"    ... and {len(skipped_large) - 10} more")
         return True
 
     # Progress tracking
@@ -1613,6 +1661,14 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
     # Step 5: Execute uploads and downloads in parallel
     if verbose:
         print(f"  Syncing {len(to_upload)} upload(s), {len(to_download)} download(s)...")
+        if skipped_large:
+            print(f"  {len(skipped_large)} file(s) above size limit ({max_upload_mb_value:g}MB). Skipping upload.")
+            print(f"  Limit: {max_upload_mb_value:g}MB (override with CC_MAX_UPLOAD_MB)")
+            for path, size in skipped_large[:10]:
+                size_mb = size / (1024 * 1024)
+                print(f"    - {path} ({size_mb:.2f} MB)")
+            if len(skipped_large) > 10:
+                print(f"    ... and {len(skipped_large) - 10} more")
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = []


### PR DESCRIPTION
## Summary
- Skip uploads above a client-side size limit (default 1MB, override via `CC_MAX_UPLOAD_MB`).
- Print a clear count message when files are skipped due to size.
- Ignore hidden paths from the server manifest to avoid `.DS_Store` re-download loops.

## Rationale
Server rejects multi‑MB uploads (HTTP 413), causing repeated sync attempts even with no local changes. The client now avoids retrying oversized files and surfaces the limit explicitly.

## Testing
- Not run (manual: `claudeconnect sync`)
