### PR TITLE
Fix #98: Encrypt all file types, not just .md

### DIFF
--- a/src/claudeconnect/encryption.py
+++ b/src/claudeconnect/encryption.py
@@ -48,7 +48,6 @@ ENCRYPTED_KEY_SIZE = 48  # 32-byte key + 16-byte GCM tag
 # Files that should NOT be encrypted (required plaintext for system)
 PLAINTEXT_FILES = {
     "authz",
-    ".keep",
 }
 
 # DEPRECATED: Previously only .md files were encrypted

--- a/tests/test_encrypt_all_files.py
+++ b/tests/test_encrypt_all_files.py
@@ -181,7 +181,6 @@ def test_all_file_types_encrypted(temp_dir, ssh_key):
 
     Files that should remain PLAINTEXT:
     - authz (required for access control)
-    - .keep (marker files)
 
     Run with: pytest tests/test_encrypt_all_files.py -s -m integration
     """
@@ -278,8 +277,8 @@ def test_encryption_unit_check():
         assert result is True, f"should_encrypt_file('{filename}') returned False, expected True"
         log(f"  ✓ {filename} -> encrypt")
 
-    # Files that should NOT be encrypted
-    should_not_encrypt = list(PLAINTEXT_FILES)  # authz, .keep
+    # Files that should NOT be encrypted (only authz)
+    should_not_encrypt = list(PLAINTEXT_FILES)  # authz
 
     for filename in should_not_encrypt:
         result = should_encrypt_file(Path(filename))


### PR DESCRIPTION
## Summary
- Changed `should_encrypt_file()` to encrypt ALL files except `authz`
- Previously only `.md` files were encrypted, leaving other file types (txt, json, yaml, png, etc.) as plaintext on the server

## Test plan
- [x] Unit test verifies `should_encrypt_file()` returns True for all file types except authz
- [x] Integration test creates various file types, syncs to server, SSHs in to verify CCENC magic bytes are present
- [x] Verified authz remains plaintext for access control

🤖 Generated with [Claude Code](https://claude.com/claude-code)