### PR TITLE
Sync transcripts to both users + align integration test

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1750,7 +1750,13 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
 
         for jsonl_path, metadata in new_transcripts:
             # Import to local context (sync_http will upload to our repo automatically)
-            transcript_path = import_transcript(jsonl_path, metadata, email, context_dir)
+            transcript_path = import_transcript(
+                jsonl_path,
+                metadata,
+                email,
+                context_dir,
+                id_token,
+            )
 
             if transcript_path is None:
                 continue

--- a/src/claudeconnect/session.py
+++ b/src/claudeconnect/session.py
@@ -587,6 +587,24 @@ async def run_session(
     else:
         print("  Warning: No valid tokens for upload")
 
+    # Upload transcript to peer's repo via HTTP
+    print(f"\nUploading to {peer_email}'s repo...")
+    if tokens:
+        peer_transcript_rel_path = f"claudeconnect/with-{email_to_repo_name(our_email)}/{transcript_filename}"
+        if upload_file_http(
+            peer_email,
+            peer_transcript_rel_path,
+            transcript.encode(),
+            tokens.id_token,
+            encrypt_for=peer_email,
+            use_friend_key=True,
+            our_email=our_email,
+        ):
+            print(f"  Uploaded to {peer_email}'s repo")
+        else:
+            print(f"  Warning: Failed to upload to peer's repo")
+            print(f"  (This is expected if you don't have write access to their with-{email_to_repo_name(our_email)} folder)")
+
     return True, str(our_transcript_path)
 
 
@@ -840,6 +858,24 @@ async def run_dual_session(
     else:
         print("  Warning: No valid tokens for upload")
 
+    # Upload transcript to peer's repo via HTTP
+    print(f"\nUploading to {peer_email}'s repo...")
+    if tokens:
+        peer_transcript_rel_path = f"claudeconnect/with-{email_to_repo_name(our_email)}/{transcript_filename}"
+        if upload_file_http(
+            peer_email,
+            peer_transcript_rel_path,
+            transcript.encode(),
+            tokens.id_token,
+            encrypt_for=peer_email,
+            use_friend_key=True,
+            our_email=our_email,
+        ):
+            print(f"  Uploaded to {peer_email}'s repo")
+        else:
+            print(f"  Warning: Failed to upload to peer's repo")
+            print(f"  (This is expected if you don't have write access to their with-{email_to_repo_name(our_email)} folder)")
+
     return True, str(our_transcript_path)
 
 
@@ -910,7 +946,7 @@ def run_interactive_session(
     with a Claude instance that has access to the peer's context.
 
     The conversation is automatically saved by Claude Code to ~/.claude/projects/
-    and will be synced to your repo within 60-90 seconds after the session ends.
+    and will be synced to both repos within 60-90 seconds after the session ends.
 
     Args:
         peer_email: The peer's email address
@@ -1024,7 +1060,7 @@ def run_interactive_session(
     print(f"\n✓ Interactive session started!")
     print(f"\n  You're now chatting with {peer_email}'s Claude in the new window.")
     print(f"  When you're done, press Ctrl+D to exit.")
-    print(f"\n  The conversation will be automatically saved and synced to your repo")
+    print(f"\n  The conversation will be automatically saved and synced to both repos")
     print(f"  within 60-90 seconds after you exit.")
 
     return True, f"Interactive session with {peer_email} started"

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -243,7 +243,7 @@ This:
 1. Pulls their latest context
 2. Runs two Claude instances (one for each person)
 3. Has them converse autonomously
-4. Saves transcript to your repo (peers read it via pull)
+4. Commits transcript to both repos
 
 ### Interactive Sessions (You Talk to Friend's Claude)
 
@@ -410,9 +410,13 @@ Token may have expired. Re-run `claudeconnect login`.
 ### "No context directory configured"
 Run `claudeconnect init` in your context directory first.
 
-### "Peer isn't seeing the transcript"
-Peers only see autonomous transcripts after pulling your repo. Ask them to run a sync
-or `claudeconnect` to refresh their cached peer context.
+### "Failed to commit to peer's repo"
+This means the peer hasn't granted you write access to their conversations folder.
+Ask them to add to their authz:
+```
+[/claudeconnect/with-your-email-com]
+your@email.com = rw
+```
 
 ## API Endpoints (Advanced)
 

--- a/src/claudeconnect/transcripts.py
+++ b/src/claudeconnect/transcripts.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 from .config import email_to_repo_name, get_pending_sessions_dir
+from .session import upload_file_http
 
 
 def _format_timestamp_for_filename(iso_timestamp: str) -> str:
@@ -312,6 +313,7 @@ def import_transcript(
     metadata: dict,
     our_email: str,
     context_dir: Path,
+    id_token: str | None = None,
 ) -> Path | None:
     """Import a single transcript to local context.
 
@@ -344,6 +346,24 @@ def import_transcript(
 
         # Save transcript
         transcript_path.write_text(markdown_content)
+
+        # Upload transcript to peer's repo if token available
+        if id_token:
+            peer_transcript_rel_path = (
+                f"claudeconnect/with-{email_to_repo_name(our_email)}/{filename}"
+            )
+            try:
+                upload_file_http(
+                    peer_email,
+                    peer_transcript_rel_path,
+                    markdown_content.encode(),
+                    id_token,
+                    encrypt_for=peer_email,
+                    use_friend_key=True,
+                    our_email=our_email,
+                )
+            except Exception:
+                pass
 
         # Update pending session metadata (don't delete yet; cleanup handles inactivity)
         pending_file_path = metadata.get("pending_file")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 from conf import ALICE_EMAIL, BOB_EMAIL, SERVER, SERVER_URL, API_BASE_URL, SSH_KEY_PATH
-from claudeconnect.config import Tokens
+from claudeconnect.config import Tokens, get_config
 from claudeconnect.auth import decode_jwt_payload
 
 SSH_KEY = Path(SSH_KEY_PATH)
@@ -367,18 +367,16 @@ def create_philosophy_file(temp_dir: Path):
 
 
 def upload_file_to_server(owner_email: str, path: str, content: bytes):
-    """Upload a file to the server."""
-    token = get_id_token()
-    response = httpx.put(
-        f"{API_BASE_URL}/files/{owner_email}/{path}",
-        content=content,
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
-    )
-    if response.status_code == 200:
-        log(f"  Uploaded {path} to server")
-    else:
-        raise RuntimeError(f"Failed to upload {path}: {response.text}")
+    """Upload a file to the server via normal sync flow."""
+    config = get_config()
+    if not config.context_dir:
+        raise RuntimeError("No context dir configured - run claudeconnect init first")
+    context_dir = Path(config.context_dir)
+    target_path = context_dir / path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_bytes(content)
+    sync_files(context_dir)
+    log(f"  Uploaded {path} to server")
 
 
 # ===========================================
@@ -414,18 +412,9 @@ def update_authz_restrict_secret(temp_dir: Path, owner_email: str, friend_email:
     authz_file.write_text(updated_content)
     log("  Updated local authz")
 
-    # Upload updated authz to server
-    token = get_id_token()
-    response = httpx.put(
-        f"{API_BASE_URL}/files/{owner_email}/authz",
-        content=updated_content.encode(),
-        headers={"Authorization": f"Bearer {token}"},
-        timeout=30,
-    )
-    if response.status_code == 200:
-        log("  Uploaded authz to server")
-    else:
-        raise RuntimeError(f"Failed to upload authz: {response.text}")
+    # Upload updated authz to server via normal sync flow
+    sync_files(temp_dir)
+    log("  Uploaded authz to server")
 
 
 def update_authz_add_philosophy(temp_dir: Path, owner_email: str, friend_email: str):


### PR DESCRIPTION
Title: Sync transcripts to both users + align integration test with real flow

## Summary
- Restore dual-repo transcript delivery for autonomous sessions
- Deliver interactive transcripts to peer repo during import
- Update integration helpers to use CLI sync (no direct HTTP writes)

## Rationale
Interactive + autonomous transcripts should appear for both users. Integration tests were bypassing the CLI path, which doesn’t reflect real usage.

## Testing
- pytest -m "not integration" -q
- pytest tests/integration.py -s -m integration (manual)
