### PR TITLE
Prevent encrypted peer writes

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -64,6 +64,7 @@ from .config import (
     get_tokens_file, get_config_file, ACTIVE_ACCOUNT_FILE, LEGACY_TOKENS_FILE,
     get_friends_dir, get_peers_dir,
 )
+from .sync_utils import write_shadow_file, write_context_if_decryptable
 # Encryption is optional - only available if cryptography is installed
 try:
     from .encryption import (
@@ -1515,8 +1516,8 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
                         plaintext = decrypt_file_with_master_key(encrypted_content, email)
                         file_path.write_bytes(plaintext)
                         decrypted_local += 1
-                except Exception:
-                    pass
+                except Exception as e:
+                    print(f"  Error: Could not decrypt {rel_path} (local context): {e}")
             stat = file_path.stat()
             context_files[rel_path] = {
                 "path": rel_path,
@@ -1696,21 +1697,29 @@ def sync_http(context_dir: Path, email: str, id_token: str, max_workers: int = 1
                 encrypted_content = response.content
 
                 # Save encrypted to shadow
-                shadow_path.parent.mkdir(parents=True, exist_ok=True)
-                shadow_path.write_bytes(encrypted_content)
+                write_shadow_file(shadow_path, encrypted_content)
 
                 # Decrypt and save to context
-                decrypted_content = encrypted_content
                 if HAS_ENCRYPTION:
-                    try:
-                        from .encryption import is_encrypted_file, decrypt_file_with_master_key
-                        if is_encrypted_file(encrypted_content):
-                            decrypted_content = decrypt_file_with_master_key(encrypted_content, email)
-                    except Exception:
-                        pass  # Keep as-is if decryption fails
+                    from .encryption import is_encrypted_file, decrypt_file_with_master_key
+                    is_encrypted_fn = is_encrypted_file
+                    decrypt_fn = lambda data: decrypt_file_with_master_key(data, email)
+                else:
+                    is_encrypted_fn = lambda _: False
+                    decrypt_fn = None
 
-                context_path.parent.mkdir(parents=True, exist_ok=True)
-                context_path.write_bytes(decrypted_content)
+                wrote_context = write_context_if_decryptable(
+                    encrypted_content=encrypted_content,
+                    context_path=context_path,
+                    path=path,
+                    can_decrypt=HAS_ENCRYPTION,
+                    decrypt_fn=decrypt_fn,
+                    is_encrypted_fn=is_encrypted_fn,
+                    error_prefix="local context",
+                )
+                if not wrote_context:
+                    with lock:
+                        errors.append(f"Decrypt {path}: failed")
                 with lock:
                     downloaded += 1
                 print_progress("DOWN", path)

--- a/src/claudeconnect/session.py
+++ b/src/claudeconnect/session.py
@@ -24,6 +24,7 @@ from .config import (
     SERVER_URL, API_BASE_URL, email_to_repo_name, get_active_account,
     get_pending_sessions_dir,
 )
+from .sync_utils import write_shadow_file, write_context_if_decryptable
 
 # Encryption imports (optional)
 try:
@@ -207,26 +208,25 @@ def pull_peer_context_http(peer_email: str, id_token: str, our_email: str, max_w
             if response.status_code == 200:
                 encrypted_content = response.content
                 shadow_path = peer_shadow_dir / path
-                shadow_path.parent.mkdir(parents=True, exist_ok=True)
-                shadow_path.write_bytes(encrypted_content)
+                write_shadow_file(shadow_path, encrypted_content)
 
                 local_path = peer_dir / path
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                if HAS_ENCRYPTION and is_encrypted_file(encrypted_content):
-                    if has_friend_master_key(peer_email, our_email):
-                        try:
-                            plaintext = decrypt_file_with_friend_master_key(
-                                encrypted_content, peer_email, our_email
-                            )
-                            local_path.write_bytes(plaintext)
-                        except Exception as e:
-                            print(f"  Warning: Could not decrypt {path}: {e}")
-                            local_path.write_bytes(encrypted_content)
-                    else:
-                        print(f"  Warning: No master key for {peer_email}, cannot decrypt {path}")
-                        local_path.write_bytes(encrypted_content)
-                else:
-                    local_path.write_bytes(encrypted_content)
+                is_encrypted_fn = is_encrypted_file if HAS_ENCRYPTION else (lambda _: False)
+                can_decrypt = HAS_ENCRYPTION and has_friend_master_key(peer_email, our_email)
+                decrypt_fn = (
+                    (lambda data: decrypt_file_with_friend_master_key(data, peer_email, our_email))
+                    if can_decrypt
+                    else None
+                )
+                write_context_if_decryptable(
+                    encrypted_content=encrypted_content,
+                    context_path=local_path,
+                    path=path,
+                    can_decrypt=can_decrypt,
+                    decrypt_fn=decrypt_fn,
+                    is_encrypted_fn=is_encrypted_fn,
+                    error_prefix="peer context",
+                )
                 return True
             return False
         except Exception:
@@ -255,16 +255,22 @@ def pull_peer_context_http(peer_email: str, id_token: str, our_email: str, max_w
         if not shadow_path.exists():
             continue
         encrypted_content = shadow_path.read_bytes()
-        if HAS_ENCRYPTION and is_encrypted_file(encrypted_content) and has_friend_master_key(peer_email, our_email):
-            try:
-                plaintext = decrypt_file_with_friend_master_key(encrypted_content, peer_email, our_email)
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                local_path.write_bytes(plaintext)
-                continue
-            except Exception:
-                pass
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        local_path.write_bytes(encrypted_content)
+        is_encrypted_fn = is_encrypted_file if HAS_ENCRYPTION else (lambda _: False)
+        can_decrypt = HAS_ENCRYPTION and has_friend_master_key(peer_email, our_email)
+        decrypt_fn = (
+            (lambda data: decrypt_file_with_friend_master_key(data, peer_email, our_email))
+            if can_decrypt
+            else None
+        )
+        write_context_if_decryptable(
+            encrypted_content=encrypted_content,
+            context_path=local_path,
+            path=path,
+            can_decrypt=can_decrypt,
+            decrypt_fn=decrypt_fn,
+            is_encrypted_fn=is_encrypted_fn,
+            error_prefix="peer context",
+        )
 
     for path in removed:
         cached_files.pop(path, None)

--- a/src/claudeconnect/sync_utils.py
+++ b/src/claudeconnect/sync_utils.py
@@ -1,0 +1,43 @@
+"""Sync utilities for handling encrypted content safely."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+
+def write_shadow_file(shadow_path: Path, content: bytes) -> None:
+    """Write encrypted content to the shadow cache."""
+    shadow_path.parent.mkdir(parents=True, exist_ok=True)
+    shadow_path.write_bytes(content)
+
+
+def write_context_if_decryptable(
+    *,
+    encrypted_content: bytes,
+    context_path: Path,
+    path: str,
+    can_decrypt: bool,
+    decrypt_fn: Callable[[bytes], bytes] | None,
+    is_encrypted_fn: Callable[[bytes], bool],
+    error_prefix: str,
+) -> bool:
+    """Write plaintext to context if possible, never ciphertext."""
+    if not is_encrypted_fn(encrypted_content):
+        context_path.parent.mkdir(parents=True, exist_ok=True)
+        context_path.write_bytes(encrypted_content)
+        return True
+
+    if not can_decrypt or decrypt_fn is None:
+        print(f"  Error: Could not decrypt {path} ({error_prefix}): missing master key")
+        return False
+
+    try:
+        plaintext = decrypt_fn(encrypted_content)
+    except Exception as exc:
+        print(f"  Error: Could not decrypt {path} ({error_prefix}): {exc}")
+        return False
+
+    context_path.parent.mkdir(parents=True, exist_ok=True)
+    context_path.write_bytes(plaintext)
+    return True

--- a/system.md
+++ b/system.md
@@ -1,0 +1,8 @@
+# System (Technical Reference)
+
+This document summarizes system behavior. See `docs/ai-situational-awareness/` for deeper architectural notes.
+
+## Sync and Decryption
+- Encrypted files are stored in the shadow cache under `~/.claude-connect/accounts/<email>/shadow/`.
+- Context directories (including peer caches under `~/.claude-connect/accounts/<email>/peers/`) only receive plaintext.
+- If a file is encrypted and the client cannot decrypt it (missing key or decryption error), the file remains only in shadow and an error is printed. Ciphertext is never written to the context directory.

--- a/tests/test_peer_pull_decryption.py
+++ b/tests/test_peer_pull_decryption.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from claudeconnect import session
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, json_data: dict | None = None, content: bytes | None = None, text: str = ""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.content = content or b""
+        self.text = text
+
+    def json(self) -> dict:
+        if self._json_data is None:
+            raise ValueError("No JSON data")
+        return self._json_data
+
+
+def test_peer_pull_skips_encrypted_context_without_key(monkeypatch, tmp_path: Path) -> None:
+    peer_email = "peer@example.com"
+    our_email = "me@example.com"
+
+    peers_dir = tmp_path / "peers"
+    shadow_root = tmp_path / "shadow"
+
+    monkeypatch.setattr(session, "get_peers_dir", lambda _: peers_dir)
+    monkeypatch.setattr(session, "get_shadow_dir", lambda _: shadow_root)
+    monkeypatch.setattr(session, "HAS_ENCRYPTION", True)
+    monkeypatch.setattr(session, "is_encrypted_file", lambda _: True)
+    monkeypatch.setattr(session, "has_friend_master_key", lambda *_: False)
+
+    def decrypt_should_not_run(*_args, **_kwargs) -> bytes:
+        raise AssertionError("decrypt should not run without key")
+
+    monkeypatch.setattr(session, "decrypt_file_with_friend_master_key", decrypt_should_not_run)
+
+    def fake_get(url: str, headers: dict | None = None, timeout: int | None = None) -> FakeResponse:
+        if "/manifest/" in url:
+            return FakeResponse(
+                200,
+                json_data={"files": [{"path": "notes.md", "sha256": "abc", "mtime": 1.0, "size": 10}]},
+            )
+        if "/files/" in url:
+            return FakeResponse(200, content=b"CCENC" + b"ciphertext")
+        return FakeResponse(404, text="not found")
+
+    monkeypatch.setattr(session.httpx, "get", fake_get)
+
+    peer_dir = session.pull_peer_context_http(peer_email, "token", our_email, max_workers=1)
+    assert peer_dir is not None
+
+    peer_name = session.email_to_repo_name(peer_email)
+    peer_shadow_path = shadow_root / "peers" / peer_name / "notes.md"
+    peer_context_path = peers_dir / peer_name / "notes.md"
+
+    assert peer_shadow_path.exists()
+    assert not peer_context_path.exists()

--- a/tests/test_sync_utils.py
+++ b/tests/test_sync_utils.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from claudeconnect.sync_utils import write_context_if_decryptable
+
+
+def is_encrypted_stub(data: bytes) -> bool:
+    return data.startswith(b"ENC:")
+
+
+def decrypt_stub(data: bytes) -> bytes:
+    if not data.startswith(b"ENC:"):
+        raise ValueError("not encrypted")
+    return data[4:]
+
+
+def test_write_context_plaintext(tmp_path: Path) -> None:
+    context_path = tmp_path / "notes.md"
+    content = b"plain text"
+
+    wrote = write_context_if_decryptable(
+        encrypted_content=content,
+        context_path=context_path,
+        path="notes.md",
+        can_decrypt=True,
+        decrypt_fn=decrypt_stub,
+        is_encrypted_fn=is_encrypted_stub,
+        error_prefix="test",
+    )
+
+    assert wrote is True
+    assert context_path.read_bytes() == content
+
+
+def test_write_context_skips_without_key(tmp_path: Path) -> None:
+    context_path = tmp_path / "secret.md"
+    content = b"ENC:secret"
+
+    wrote = write_context_if_decryptable(
+        encrypted_content=content,
+        context_path=context_path,
+        path="secret.md",
+        can_decrypt=False,
+        decrypt_fn=None,
+        is_encrypted_fn=is_encrypted_stub,
+        error_prefix="test",
+    )
+
+    assert wrote is False
+    assert not context_path.exists()
+
+
+def test_write_context_skips_on_decrypt_error(tmp_path: Path) -> None:
+    context_path = tmp_path / "secret.md"
+    content = b"ENC:secret"
+
+    def decrypt_raises(_: bytes) -> bytes:
+        raise ValueError("boom")
+
+    wrote = write_context_if_decryptable(
+        encrypted_content=content,
+        context_path=context_path,
+        path="secret.md",
+        can_decrypt=True,
+        decrypt_fn=decrypt_raises,
+        is_encrypted_fn=is_encrypted_stub,
+        error_prefix="test",
+    )
+
+    assert wrote is False
+    assert not context_path.exists()
+
+
+def test_write_context_decrypts(tmp_path: Path) -> None:
+    context_path = tmp_path / "secret.md"
+    content = b"ENC:secret"
+
+    wrote = write_context_if_decryptable(
+        encrypted_content=content,
+        context_path=context_path,
+        path="secret.md",
+        can_decrypt=True,
+        decrypt_fn=decrypt_stub,
+        is_encrypted_fn=is_encrypted_stub,
+        error_prefix="test",
+    )
+
+    assert wrote is True
+    assert context_path.read_bytes() == b"secret"


### PR DESCRIPTION
## Summary
- add sync helper to avoid writing ciphertext into context dirs
- enforce decrypt-or-skip for peer pulls and sync downloads with errors
- add unit tests for decrypt guard and helper
- document behavior in system.md

## Testing
- pytest tests/test_sync_utils.py -q
- pytest tests/test_peer_pull_decryption.py -q