### PR TITLE
Fix: clamp banner width to terminal

### DIFF
--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -42,6 +42,8 @@ from .terminal_ui import (
     DIM,
     LIME,
     RESET,
+    WRAP_OFF,
+    WRAP_ON,
     WHITE,
     build_banner_box_lines,
     get_dashboard_width,
@@ -101,19 +103,24 @@ def display_startup_banner(context_dir: Path, email: str, clear_screen: bool = T
     if clear_screen:
         print(CLEAR, end='')
 
-    print()
-    width = get_dashboard_width()
-    for line in build_banner_box_lines(email, peer_name, width):
-        print(line)
+    try:
+        # Disable line wrapping while drawing the banner to avoid box reflow artifacts.
+        print(WRAP_OFF, end='')
+        print()
+        width = get_dashboard_width()
+        for line in build_banner_box_lines(email, peer_name, width):
+            print(line)
 
-    print()
+        print()
 
-    # For interactive sessions, show simplified banner and skip notifications
-    if peer_name:
-        print(RESET, end='', flush=True)
-        return
+        # For interactive sessions, show simplified banner and skip notifications
+        if peer_name:
+            print(RESET, end='', flush=True)
+            return
 
-    display_notifications(context_dir)
+        display_notifications(context_dir)
+    finally:
+        print(WRAP_ON, end='')
 
 
 def build_soft_banner_lines(context_dir: Path, email: str, peer_name: str | None = None) -> list[str]:

--- a/src/claudeconnect/terminal_ui.py
+++ b/src/claudeconnect/terminal_ui.py
@@ -43,6 +43,8 @@ ORIGIN_MODE_OFF = '\033[?6l'
 RESET_SCROLL_REGION = '\033[r'
 SAVE_CURSOR = '\0337'
 RESTORE_CURSOR = '\0338'
+WRAP_OFF = '\033[?7l'
+WRAP_ON = '\033[?7h'
 
 
 def get_cell_aspect_ratio() -> float | None:


### PR DESCRIPTION
## Summary
- clamp CC dashboard width to the current terminal width
- allow CC_DASHBOARD_WIDTH=full/max to fill available columns safely

## Rationale
Avoid border wrapping when the terminal is narrower than the requested banner width.

## Testing
- not run (layout-only change)