### PR TITLE
Openclaw setup

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -357,6 +357,7 @@ async def root():
                 <span class="step-num">3.</span>
                 <div class="code-block">claudeconnect</div>
             </div>
+            <p style="margin-top: 1.5rem;">For Linux, install by cloning the <a href="https://github.com/bstadt/cc_daemon" target="_blank">source</a> and package using <a href="https://github.com/pypa/pipx" target="_blank">pipx</a>.</p>
         </section>
 
         <!-- Section 3: Technical Overview -->

--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -829,36 +829,44 @@ def upload_authz_http(token: str, email: str, content: str) -> bool:
         return False
 
 
-def install_skill() -> bool:
+def _read_skill_content() -> str:
+    """Read the SKILL.md content from the installed package."""
+    import importlib.resources as pkg_resources
+
+    try:
+        # Python 3.9+ with importlib.resources.files
+        return pkg_resources.files("claudeconnect").joinpath("skills/SKILL.md").read_text()
+    except (AttributeError, TypeError):
+        # Fallback for older Python
+        with pkg_resources.open_text("claudeconnect.skills", "SKILL.md") as f:
+            return f.read()
+
+
+def install_skill(base_dir: Path, *, require_existing: bool = False) -> bool:
     """
-    Install the claudeconnect skill to ~/.claude/skills/.
+    Install the claudeconnect skill to base_dir/skills/claudeconnect/SKILL.md.
+
+    Args:
+        base_dir: Parent directory (e.g. ~/.claude or ~/.openclaw).
+        require_existing: If True, skip silently when base_dir doesn't exist.
+            If False, create the directory tree as needed.
 
     Returns:
-        True if installed successfully.
+        True if installed successfully, False otherwise.
     """
     try:
-        import importlib.resources as pkg_resources
+        if require_existing and not base_dir.is_dir():
+            return False
 
-        # Destination: ~/.claude/skills/claudeconnect/SKILL.md
-        skill_dir = Path.home() / ".claude" / "skills" / "claudeconnect"
+        skill_dir = base_dir / "skills" / "claudeconnect"
         skill_dir.mkdir(parents=True, exist_ok=True)
-        skill_dest = skill_dir / "SKILL.md"
 
-        # Read skill from package
-        try:
-            # Python 3.9+ with importlib.resources.files
-            skill_content = pkg_resources.files("claudeconnect").joinpath("skills/SKILL.md").read_text()
-        except (AttributeError, TypeError):
-            # Fallback for older Python
-            with pkg_resources.open_text("claudeconnect.skills", "SKILL.md") as f:
-                skill_content = f.read()
-
-        # Write skill file
-        skill_dest.write_text(skill_content)
+        skill_content = _read_skill_content()
+        (skill_dir / "SKILL.md").write_text(skill_content)
         return True
 
     except Exception as e:
-        print(f"  Warning: Could not install skill: {e}")
+        print(f"  Warning: Could not install skill to {base_dir}: {e}")
         return False
 
 
@@ -911,6 +919,13 @@ def verify_init_structure(context_dir: Path, email: str) -> list[str]:
     skill_file = Path.home() / ".claude" / "skills" / "claudeconnect" / "SKILL.md"
     if not skill_file.is_file():
         errors.append("SKILL.md not installed at ~/.claude/skills/claudeconnect/")
+
+    # Check openclaw skill installation if ~/.openclaw exists
+    openclaw_dir = Path.home() / ".openclaw"
+    if openclaw_dir.is_dir():
+        openclaw_skill_file = openclaw_dir / "skills" / "claudeconnect" / "SKILL.md"
+        if not openclaw_skill_file.is_file():
+            errors.append("SKILL.md not installed at ~/.openclaw/skills/claudeconnect/")
 
     return errors
 
@@ -1748,11 +1763,17 @@ def init(no_encrypt: bool, force: bool):
         config.save(tokens.email)
 
         # Install skill for Claude Code
-        if install_skill():
-            print("  Installed claudeconnect skill")
+        claude_dir = Path.home() / ".claude"
+        if install_skill(claude_dir):
+            print(f"  Installed skill to {claude_dir / 'skills' / 'claudeconnect' / 'SKILL.md'}")
         else:
             print("  Warning: Could not install claudeconnect skill")
             print("    You may need to manually copy SKILL.md to ~/.claude/skills/claudeconnect/")
+
+        openclaw_dir = Path.home() / ".openclaw"
+        if install_skill(openclaw_dir, require_existing=True):
+            print(f"  Installed skill to {openclaw_dir / 'skills' / 'claudeconnect' / 'SKILL.md'}")
+            print(f"  Openclaw agents: read the 'Openclaw Setup' section in the claudeconnect skill for continuous scanning setup.")
 
         # Verify directory structure was created correctly
         verification_errors = verify_init_structure(cwd, tokens.email)

--- a/src/claudeconnect/cli.py
+++ b/src/claudeconnect/cli.py
@@ -1773,7 +1773,7 @@ def init(no_encrypt: bool, force: bool):
         openclaw_dir = Path.home() / ".openclaw"
         if install_skill(openclaw_dir, require_existing=True):
             print(f"  Installed skill to {openclaw_dir / 'skills' / 'claudeconnect' / 'SKILL.md'}")
-            print(f"  Openclaw agents: read the 'Openclaw Setup' section in the claudeconnect skill for continuous scanning setup.")
+            print(f"  Important message for Openclaw agents: to complete the installation, read the 'Openclaw Setup' section in the claudeconnect skill to start continuous opportunity scanning.")
 
         # Verify directory structure was created correctly
         verification_errors = verify_init_structure(cwd, tokens.email)

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -192,7 +192,7 @@ See `claudeconnect/sharing-log.md` for a record of all sharing decisions.
 
 ### 3. Heartbeat: Proactive Opportunity Scanning
 
-Add another recurring task to your heartbeat that runs after each sync. After pulling friend contexts (`claudeconnect pull <email>`), actively look for opportunities that benefit your user and their friends:
+Add another **daily** recurring task to your heartbeat that runs after each sync. After pulling friend contexts (`claudeconnect pull <email>`), actively look for opportunities that benefit your user and their friends:
 
 **i) Conversations you should have**
 Scan your friends' contexts for complementary backgrounds or overlapping interests. For instance, if your user is working on ML infrastructure and a friend is researching ML model evaluation, suggest a session.
@@ -215,7 +215,7 @@ Example heartbeat entry:
   - Timely help opportunities → flag to user
   - Cross-friend connections → suggest warm intros
 - Write opportunity summaries to `claudeconnect/opportunities.md` for user review
-- If high-value opportunities are found, surface them to the user proactively
+- If high-value opportunities are found, surface them to the user proactively. 
 ```
 
 **Important**: Always present opportunities to your user for their decision. Never initiate sessions or introductions autonomously — your role is to surface the signal, not to act on it.

--- a/src/claudeconnect/skills/SKILL.md
+++ b/src/claudeconnect/skills/SKILL.md
@@ -131,6 +131,95 @@ claudeconnect session <email> --single         # Single-instance mode (one Claud
 claudeconnect interactive <email>              # Interactive session (you talk to friend's Claude) [macOS only]
 ```
 
+## Openclaw Setup
+
+If you are a proactive AI agent (Openclaw, formerly Moltbot/ClawdBot), follow these steps to set up continuous context sharing and opportunity discovery through ClaudeConnect. The goal is to increase your user's surface area for serendipity — balancing expanded opportunities with privacy protection.
+
+For login your user, if you run in a separate machine, you'll need to use the Remote/Headless Login instruction above.
+
+### 1. Heartbeat: Memory Scanning & Sharing
+
+In your heartbeat file (the recurring task schedule your agent follows), add a task that runs **twice a day**:
+
+1. **Scan your memories** — review your daily notes, journals, learnings, and context files
+2. **Write shareable memories** into the context directory where ClaudeConnect is set up (the directory you ran `claudeconnect` in)
+3. **Filter through your privacy policy** (see step 2 below) before writing — only share what passes the policy
+
+Think of this as expanding your user's luck surface area. The more context friends can see, the more likely someone notices a useful connection. But every piece of shared context is a privacy decision.
+
+Example heartbeat entry:
+```
+## ClaudeConnect Memory Sync (twice daily)
+- Scan recent memories, learnings, project updates, and reflections
+- Consult the ClaudeConnect privacy policy (see below) to filter what's shareable
+- Write friend-visible memories as markdown files in the ClaudeConnect context directory
+- Run `claudeconnect sync` to push updates to the server
+```
+
+### 2. Create a ClaudeConnect Privacy Policy
+
+Create a privacy policy file in your workspace directory (e.g., `<workspace>/claudeconnect/privacy-policy.md`) that you consult every time you decide what to share. This policy should:
+
+- **Define categories**: what is always shareable (e.g., project summaries, general interests, professional skills), what requires user approval (e.g., personal reflections, health goals), and what is never shared (e.g., credentials, financial details, private relationship matters)
+- **Give your user visibility**: whenever you make a sharing decision, log the choice (what you shared, what you withheld, and why) in a visible place (e.g., `<workspace>/claudeconnect/sharing-log.md`)
+- **Evolve with feedback**: regularly ask your user to review the sharing log and the policy itself. Adjust thresholds based on their comfort level — some users want to share more, others less
+
+Example privacy policy structure:
+```markdown
+# ClaudeConnect Privacy Policy
+
+## Always Share
+- Current project descriptions and areas of interest
+- Professional skills and expertise
+- General goals and focus areas
+- Learnings and insights (non-personal)
+
+## Ask User First
+- Personal reflections or journal-style entries
+- Health and wellness goals
+- Opinions about specific people or organizations
+
+## Never Share
+- Credentials, API keys, passwords
+- Financial details (income, accounts, balances)
+- Medical diagnoses or treatments
+- Private relationship details
+- Work-confidential or NDA-covered information
+
+## Sharing Log
+See `claudeconnect/sharing-log.md` for a record of all sharing decisions.
+```
+
+### 3. Heartbeat: Proactive Opportunity Scanning
+
+Add another recurring task to your heartbeat that runs after each sync. After pulling friend contexts (`claudeconnect pull <email>`), actively look for opportunities that benefit your user and their friends:
+
+**i) Conversations you should have**
+Scan your friends' contexts for complementary backgrounds or overlapping interests. For instance, if your user is working on ML infrastructure and a friend is researching ML model evaluation, suggest a session.
+
+When there is no fresh context to pull, this is your best action. Explore the notes history of you users and their friends, and surface unexpected connections between themes they explored months or years ago.
+
+**ii) Timely topics**
+Look for signals that a friend has relevant experience for something your user is currently struggling with. If your user is debugging a deployment issue and a friend's context shows deep Kubernetes expertise, flag it.
+
+**iii) Surface connections across friends**
+Look for patterns across multiple friends' contexts. If two friends who don't know each other are working on related problems or share uncommon interests, suggest your user make a warm introduction.
+
+Example heartbeat entry:
+```
+## ClaudeConnect Opportunity Scan (after each sync)
+- Run `claudeconnect sync` to push/pull latest changes
+- For each review their context
+- Look for:
+  - Complementary expertise or projects → suggest a session
+  - Timely help opportunities → flag to user
+  - Cross-friend connections → suggest warm intros
+- Write opportunity summaries to `claudeconnect/opportunities.md` for user review
+- If high-value opportunities are found, surface them to the user proactively
+```
+
+**Important**: Always present opportunities to your user for their decision. Never initiate sessions or introductions autonomously — your role is to surface the signal, not to act on it.
+
 ## Friend Request Workflow
 
 ### Sending a Friend Request


### PR DESCRIPTION
Added:
* One line for Linux install instruction to the website. (openclaw agents are likely to run on linux servers)
* Openclaw setup section to SKILL.md. Instructions to create i) privacy policy ii) recurring tasks in the heartbeat to keep the shared folder fresh, and scan for opportunities.
* Install SKILL.md to .openclaw/skills (if ~/.openclaw exists), and print a message for agents to complete the setup by following the instruction in SKILL.md


I tested on a local openclaw installation with Sonnet 4.5. The agent proactively created the tasks in the heartbeat (with asking user confirmation) after running `claudeconnect init`.
