### PR TITLE
fix(server): unify Google OAuth client id env + fail closed on audience verification

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,5 +1,7 @@
 """ClaudeConnect v2s Sync Server - FastAPI Application."""
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -17,10 +19,29 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Fail closed: refuse to start without a Google OAuth client id. It is required
+    # to verify the audience of incoming Google ID tokens (see server/auth.py); if
+    # it is missing, the server would otherwise accept tokens issued for any other
+    # Google app. Failing startup turns a silent auth-bypass into a loud
+    # misconfiguration. (Checked at startup, not import, so the package stays
+    # importable for tests/tooling.)
+    if not settings.google_client_id:
+        raise RuntimeError(
+            "GOOGLE_CLIENT_ID is not set. Refusing to start: it is required to "
+            "verify Google ID token audiences. Set GOOGLE_CLIENT_ID (or "
+            "CC_GOOGLE_CLIENT_ID) in the environment."
+        )
+    yield
+
+
 app = FastAPI(
     title="ClaudeConnect Sync Server",
     description="HTTP-based file sync server for ClaudeConnect",
     version="2.0.0",
+    lifespan=lifespan,
 )
 
 # CORS - allow client access

--- a/server/auth.py
+++ b/server/auth.py
@@ -60,14 +60,26 @@ def validate_google_id_token(token: str) -> Optional[TokenPayload]:
     Returns:
         TokenPayload with user info if valid, None if invalid
     """
+    # Fail closed: without a configured client id we cannot verify the token's
+    # audience, and an unverified audience means tokens minted for *any* Google
+    # app would be accepted. Reject rather than silently downgrade. (server/app.py
+    # also refuses to start without it; this guards direct/library callers.)
+    if not settings.google_client_id:
+        logger.error(
+            "google_client_id is not configured; refusing to validate Google ID "
+            "tokens (cannot verify audience). Set GOOGLE_CLIENT_ID."
+        )
+        return None
+
     try:
         # Get the signing key from Google's JWKS
         jwk_client = _get_jwk_client()
         signing_key = jwk_client.get_signing_key_from_jwt(token)
 
-        # Decode and verify the token
+        # Decode and verify the token. Audience is always verified against this
+        # server's OAuth client id — see the fail-closed guard above.
         decode_options = {
-            "verify_aud": bool(settings.google_client_id),
+            "verify_aud": True,
             "verify_iss": True,
             "verify_exp": True,
         }
@@ -76,7 +88,7 @@ def validate_google_id_token(token: str) -> Optional[TokenPayload]:
             token,
             signing_key.key,
             algorithms=["RS256"],
-            audience=settings.google_client_id if settings.google_client_id else None,
+            audience=settings.google_client_id,
             issuer=GOOGLE_ISSUERS,
             options=decode_options,
         )

--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,7 @@
 """Server configuration."""
 
 from pathlib import Path
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -15,8 +16,28 @@ class Settings(BaseSettings):
     # Data storage
     data_dir: Path = Path("/data/users")
 
-    # Google OAuth (for JWT validation)
-    google_client_id: str = ""
+    # Google OAuth — the single source of truth for BOTH the login flow
+    # (routes/oauth.py) and ID-token audience verification (auth.py). These are
+    # read from the un-prefixed env names (the canonical deploy vars); the
+    # CC_-prefixed names are also accepted for backwards compatibility.
+    #
+    # IMPORTANT: keep these on one Settings field. Historically oauth.py read
+    # GOOGLE_CLIENT_ID while auth.py read CC_GOOGLE_CLIENT_ID, so a deploy could
+    # set one and not the other — login worked but audience verification silently
+    # turned off (tokens minted for any other Google app were accepted). One field
+    # makes that split impossible.
+    google_client_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("GOOGLE_CLIENT_ID", "CC_GOOGLE_CLIENT_ID"),
+    )
+    google_client_secret: str = Field(
+        default="",
+        validation_alias=AliasChoices("GOOGLE_CLIENT_SECRET", "CC_GOOGLE_CLIENT_SECRET"),
+    )
+    server_base_url: str = Field(
+        default="https://claudeconnect.io",
+        validation_alias=AliasChoices("SERVER_BASE_URL", "CC_SERVER_BASE_URL"),
+    )
 
     # Optional: restrict to specific emails/domains
     allowed_domains: list[str] = []

--- a/server/routes/oauth.py
+++ b/server/routes/oauth.py
@@ -1,6 +1,5 @@
 """OAuth endpoints for login and token refresh."""
 
-import os
 import logging
 from urllib.parse import urlencode, quote
 
@@ -8,18 +7,17 @@ from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
 import httpx
 
+from ..config import settings
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["oauth"])
 
-# Google OAuth configuration
-GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
-GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
+# Google OAuth configuration. The client id/secret and base URL come from the
+# shared Settings object (server/config.py) so this login flow and the ID-token
+# audience check in auth.py can never read different values.
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-
-# This server's base URL (for OAuth callback)
-SERVER_BASE_URL = os.environ.get("SERVER_BASE_URL", "https://claudeconnect.io")
 
 
 @router.get("/login")
@@ -30,7 +28,7 @@ async def login(redirect_uri: str = Query(..., description="Client callback URL"
     Redirects to Google OAuth, which will redirect back to /oauth/callback,
     which will then redirect to the client's redirect_uri with tokens.
     """
-    if not GOOGLE_CLIENT_ID:
+    if not settings.google_client_id:
         raise HTTPException(status_code=500, detail="Google OAuth not configured")
 
     # Store the client's redirect_uri in state (we'll pass it through OAuth)
@@ -38,8 +36,8 @@ async def login(redirect_uri: str = Query(..., description="Client callback URL"
     state = quote(redirect_uri)
 
     params = {
-        "client_id": GOOGLE_CLIENT_ID,
-        "redirect_uri": f"{SERVER_BASE_URL}/callback",
+        "client_id": settings.google_client_id,
+        "redirect_uri": f"{settings.server_base_url}/callback",
         "response_type": "code",
         "scope": "openid email",
         "access_type": "offline",
@@ -73,7 +71,7 @@ async def oauth_callback(
     if not code or not state:
         raise HTTPException(status_code=400, detail="Missing code or state")
 
-    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+    if not settings.google_client_id or not settings.google_client_secret:
         raise HTTPException(status_code=500, detail="Google OAuth not configured")
 
     # Exchange code for tokens
@@ -82,11 +80,11 @@ async def oauth_callback(
             response = await client.post(
                 GOOGLE_TOKEN_URL,
                 data={
-                    "client_id": GOOGLE_CLIENT_ID,
-                    "client_secret": GOOGLE_CLIENT_SECRET,
+                    "client_id": settings.google_client_id,
+                    "client_secret": settings.google_client_secret,
                     "code": code,
                     "grant_type": "authorization_code",
-                    "redirect_uri": f"{SERVER_BASE_URL}/callback",
+                    "redirect_uri": f"{settings.server_base_url}/callback",
                 },
             )
             response.raise_for_status()
@@ -118,7 +116,7 @@ async def refresh_token(refresh_token: str = Query(..., description="Refresh tok
     """
     Refresh an expired id_token using the refresh token.
     """
-    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+    if not settings.google_client_id or not settings.google_client_secret:
         raise HTTPException(status_code=500, detail="Google OAuth not configured")
 
     try:
@@ -126,8 +124,8 @@ async def refresh_token(refresh_token: str = Query(..., description="Refresh tok
             response = await client.post(
                 GOOGLE_TOKEN_URL,
                 data={
-                    "client_id": GOOGLE_CLIENT_ID,
-                    "client_secret": GOOGLE_CLIENT_SECRET,
+                    "client_id": settings.google_client_id,
+                    "client_secret": settings.google_client_secret,
                     "refresh_token": refresh_token,
                     "grant_type": "refresh_token",
                 },

--- a/tests/test_google_token_audience.py
+++ b/tests/test_google_token_audience.py
@@ -1,0 +1,99 @@
+"""Regression tests for Google ID token audience verification.
+
+Guards against the audience-verification bypass: a token minted for a *different*
+Google OAuth app must be rejected, and validation must fail closed when no client
+id is configured. See server/auth.py and the GOOGLE_CLIENT_ID / CC_GOOGLE_CLIENT_ID
+unification in server/config.py.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+import server.auth as auth_module
+from server.config import settings
+
+OUR_CLIENT_ID = "our-app.apps.googleusercontent.com"
+OTHER_CLIENT_ID = "some-other-app.apps.googleusercontent.com"
+
+
+class _FakeSigningKey:
+    def __init__(self, key):
+        self.key = key
+
+
+@pytest.fixture
+def rsa_keypair():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+@pytest.fixture
+def patched_auth(monkeypatch, rsa_keypair):
+    """Point auth validation at a key we control and a known client id."""
+    _priv, pub = rsa_keypair
+
+    class _FakeJWKClient:
+        def get_signing_key_from_jwt(self, _token):
+            return _FakeSigningKey(pub)
+
+    monkeypatch.setattr(auth_module, "_get_jwk_client", lambda: _FakeJWKClient())
+    monkeypatch.setattr(settings, "google_client_id", OUR_CLIENT_ID)
+    return rsa_keypair
+
+
+def _make_token(private_key, aud, **overrides):
+    now = int(time.time())
+    claims = {
+        "iss": "https://accounts.google.com",
+        "aud": aud,
+        "email": "user@example.com",
+        "email_verified": True,
+        "sub": "subject-123",
+        "iat": now,
+        "exp": now + 3600,
+    }
+    claims.update(overrides)
+    return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": "test"})
+
+
+def test_token_for_our_app_is_accepted(patched_auth):
+    priv, _pub = patched_auth
+    token = _make_token(priv, aud=OUR_CLIENT_ID)
+    payload = auth_module.validate_google_id_token(token)
+    assert payload is not None
+    assert payload.email == "user@example.com"
+
+
+def test_token_for_other_app_is_rejected(patched_auth):
+    """The core fix: a validly Google-signed token minted for a different app
+    (different aud) must NOT authenticate against this server."""
+    priv, _pub = patched_auth
+    token = _make_token(priv, aud=OTHER_CLIENT_ID)
+    assert auth_module.validate_google_id_token(token) is None
+
+
+def test_fails_closed_when_no_client_id(monkeypatch, rsa_keypair):
+    """With no configured client id, validation must reject everything rather
+    than silently skip the audience check."""
+    priv, pub = rsa_keypair
+
+    class _FakeJWKClient:
+        def get_signing_key_from_jwt(self, _token):
+            return _FakeSigningKey(pub)
+
+    monkeypatch.setattr(auth_module, "_get_jwk_client", lambda: _FakeJWKClient())
+    monkeypatch.setattr(settings, "google_client_id", "")
+
+    token = _make_token(priv, aud=OUR_CLIENT_ID)
+    assert auth_module.validate_google_id_token(token) is None
+
+
+def test_unverified_email_rejected(patched_auth):
+    priv, _pub = patched_auth
+    token = _make_token(priv, aud=OUR_CLIENT_ID, email_verified=False)
+    assert auth_module.validate_google_id_token(token) is None


### PR DESCRIPTION
## The bug

The login flow (`routes/oauth.py`) read **`GOOGLE_CLIENT_ID`** while the ID-token validator (`auth.py`) read **`CC_GOOGLE_CLIENT_ID`** (via `settings`). Same value, two names, no cross-check.

Because audience verification was gated on whether that second var happened to be set —

```python
"verify_aud": bool(settings.google_client_id),
audience=settings.google_client_id if settings.google_client_id else None,
```

— a deploy that set only `GOOGLE_CLIENT_ID` (so login worked) but not `CC_GOOGLE_CLIENT_ID` would **silently disable `aud` verification**. The check degrades from "is this a token *for us*" to "is this *any* valid, unexpired, Google-signed token for a verified email." A token minted for **any other Google OAuth app** (trivially: an attacker stands up their own app, gets a victim to sign in, replays the token) is then accepted as a valid login for that user — full access to their files/keys/friend graph. This was live on the production server.

## The fix

Two complementary changes — remove the footgun, and make the check fail closed:

- **`config.py`** — one `google_client_id` Settings field (plus `google_client_secret`, `server_base_url`), read from the un-prefixed env names via `AliasChoices` (CC_-prefixed names still accepted for back-compat). One field → the two readers can't diverge.
- **`oauth.py`** — reads these from the shared `settings` object instead of `os.environ`, so the login flow and the audience check are guaranteed to use the same value.
- **`auth.py`** — `verify_aud` is now **unconditional**; if no client id is configured, validation **fails closed** (rejects all tokens) instead of silently skipping the check.
- **`app.py`** — the server **refuses to start** (lifespan hook) without a client id, turning a silent auth-bypass into a loud misconfiguration. (Checked at startup, not import, so the package stays importable for tests/tooling.)

## Tests

New `tests/test_google_token_audience.py` (signs tokens with a controlled key + stubs the JWKS lookup):

- ✅ token with **our** `aud` is accepted
- ✅ token with a **foreign** `aud` is **rejected** ← the regression
- ✅ **fails closed** when no client id is configured
- ✅ unverified email rejected

All pass; existing `test_bot_auth.py` unaffected (14 passed together with `CC_BOT_JWT_SECRET` + `GOOGLE_CLIENT_ID` set).

## Deploy / ops notes

- **No Google Cloud Console changes needed** — `aud` is stamped by Google with the requesting client id; this only makes the server *require and verify* it.
- **No env changes needed** on existing deploys that set `GOOGLE_CLIENT_ID` — that name is still read.
- After this, any box missing the client id will **fail to boot** rather than serve insecurely (intended). The live server already has it set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)